### PR TITLE
Use SQLite for Persistence

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,22 @@
 version: 2.1
 
 jobs:
+
+  test_dtserver:
+    docker:
+      - image: cimg/python:3.6
+    steps:
+      - checkout
+      - run:
+          name: "Install DTServer dependencies"
+          command: "pip install -e src/dativetop/server[testing]"
+      - run:
+          name: "Build the DTServer SQLite database"
+          command: "initialize_dtserver_db src/dativetop/server/config.ini"
+      - run:
+          name: "Run the DTServer tests"
+          command: "pytest src/dativetop/server/tests"
+
   build-dativetop-gui:
     docker:
       - image: cimg/base:2020.10
@@ -13,8 +29,8 @@ jobs:
           name: Build Docker image
           command: cd docker build -t $IMAGE_NAME:latest .
 
-# workflows:
-#   version: 2
-#   "test_old":
-#     jobs:
-#       - test
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test_dtserver

--- a/src/dativetop/server/README.rst
+++ b/src/dativetop/server/README.rst
@@ -8,3 +8,20 @@ that can be read, with GET, and appended to, with PUT.
 Serve it::
 
     $ pserve --reload config.ini http_port=4676 http_host=127.0.0.1
+
+Run the tests::
+
+    $ pytest
+
+Install dependencies::
+
+    $ pip install -e .
+
+Build the database tables::
+
+    $ initialize_dtserver_db config.ini
+
+Open a shell::
+
+    $ pshell config.ini
+

--- a/src/dativetop/server/config.ini
+++ b/src/dativetop/server/config.ini
@@ -13,6 +13,8 @@ pyramid.debug_routematch = false
 pyramid.default_locale_name = en
 # pyramid.includes = pyramid_debugtoolbar
 
+sqlalchemy.url = sqlite:///%(here)s/dativetop.sqlite
+
 # By default, the toolbar only appears for clients from IP addresses
 # '127.0.0.1' and '::1'.
 # debugtoolbar.hosts = 127.0.0.1 ::1
@@ -35,7 +37,7 @@ port = %(http_port)s
 ###
 
 [loggers]
-keys = root, dativetopserver
+keys = root, dativetopserver, sqlalchemy.engine.base.Engine
 
 [handlers]
 keys = console
@@ -52,6 +54,11 @@ level = INFO
 handlers = console
 qualname = dativetopserver
 propagate = 0
+
+[logger_sqlalchemy.engine.base.Engine]
+level = INFO
+handlers = console
+qualname = sqlalchemy.engine.base.Engine
 
 [handler_console]
 class = StreamHandler

--- a/src/dativetop/server/dativetopserver/__init__.py
+++ b/src/dativetop/server/dativetopserver/__init__.py
@@ -1,11 +1,16 @@
 from pyramid.config import Configurator
+from sqlalchemy import engine_from_config
 
+from .models import DBSession, Base
 import dativetopserver.views as views
 
 
 def main(global_config, **settings):
     """ This function returns a Pyramid WSGI application.
     """
+    engine = engine_from_config(settings, 'sqlalchemy.')
+    DBSession.configure(bind=engine)
+    Base.metadata.bind = engine
     config = Configurator(settings=settings)
     config.include('pyramid_chameleon')
     config.include('dativetopserver.cors')

--- a/src/dativetop/server/dativetopserver/initialize_db.py
+++ b/src/dativetop/server/dativetopserver/initialize_db.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import transaction
+
+from sqlalchemy import engine_from_config
+
+from pyramid.paster import (
+    get_appsettings,
+    setup_logging,
+    )
+
+from .models import (
+    DBSession,
+    DativeApp,
+    Base,
+    )
+
+
+def usage(argv):
+    cmd = os.path.basename(argv[0])
+    print('usage: %s <config_uri>\n'
+          '(example: "%s development.ini")' % (cmd, cmd))
+    sys.exit(1)
+
+
+def main(argv=sys.argv):
+    if len(argv) != 2:
+        usage(argv)
+    config_uri = argv[1]
+    setup_logging(config_uri)
+    settings = get_appsettings(config_uri)
+    engine = engine_from_config(settings, 'sqlalchemy.')
+    DBSession.configure(bind=engine)
+    Base.metadata.create_all(engine)

--- a/src/dativetop/server/dativetopserver/models.py
+++ b/src/dativetop/server/dativetopserver/models.py
@@ -1,0 +1,322 @@
+from collections import namedtuple
+import datetime
+import json
+import transaction
+from uuid import uuid4
+
+from pyramid.authorization import Allow, Everyone
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    Unicode,
+    UnicodeText,
+)
+
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import asc
+from sqlalchemy.orm.exc import (
+    NoResultFound,
+    MultipleResultsFound,
+)
+from sqlalchemy.orm import (
+    scoped_session,
+    sessionmaker,
+)
+
+from zope.sqlalchemy import register
+
+
+DBSession = scoped_session(sessionmaker())
+register(DBSession)
+Base = declarative_base()
+
+
+def gen_uuid():
+    return str(uuid4())
+
+
+def get_now():
+    return datetime.datetime.utcnow()
+
+
+old_state = namedtuple(
+    'OLDState', (
+        'not_synced',
+        'syncing',
+        'synced',
+        'failed_to_sync',
+    )
+)(*range(4))
+
+
+class DativeApp(Base):
+    __tablename__ = 'dativeapp'
+    uuid = Column(String(length=36), primary_key=True, default=gen_uuid)
+    history_id = Column(String(length=36), default=gen_uuid, index=True)
+    url = Column(Unicode(length=512))
+    start = Column(DateTime, default=get_now)
+    end = Column(DateTime, default=datetime.datetime.max, index=True)
+
+
+class OLDService(Base):
+    __tablename__ = 'oldservice'
+    uuid = Column(String(length=36), primary_key=True, default=gen_uuid)
+    history_id = Column(String(length=36), default=gen_uuid, index=True)
+    url = Column(Text)
+    start = Column(DateTime, default=get_now)
+    end = Column(DateTime, default=datetime.datetime.max, index=True)
+
+
+class OLD(Base):
+    __tablename__ = 'old'
+    uuid = Column(String(length=36), primary_key=True, default=gen_uuid)
+    history_id = Column(String(length=36), default=gen_uuid, index=True)
+    # unique among OLD instances at a given OLDService.url, e.g., "oka"
+    slug = Column(Unicode(length=256), nullable=False, index=True)
+    # human readable name, e.g., "Okanagan"
+    name = Column(Unicode(length=256), nullable=False)
+    # Leader is the URL of an external OLD instance that this OLD instance
+    # follows and syncs with. The username and password are the credentials for
+    # authenticating to the leader.
+    leader = Column(Unicode(length=512))
+    username = Column(Unicode(length=256))
+    password = Column(Unicode(length=256))
+    state = Column(Integer, default=old_state.not_synced) # see old_state above
+    # setting indicates whether DativeTop should continuously and
+    # automatically keep this local OLDInstance in sync with its leader.
+    is_auto_syncing = Column(Boolean, default=False)
+    start = Column(DateTime, default=get_now)
+    end = Column(DateTime, default=datetime.datetime.max, index=True)
+
+
+class SyncOLDCommand(Base):
+    __tablename__ = 'syncoldcommand'
+    uuid = Column(String(length=36), primary_key=True, default=gen_uuid)
+    history_id = Column(String(length=36), default=gen_uuid, index=True)
+    old_id = Column(Integer, ForeignKey('old.history_id'), index=True)
+    acked = Column(Boolean, default=False, index=True)
+    start = Column(DateTime, default=get_now, index=True)
+    end = Column(DateTime, default=datetime.datetime.max, index=True)
+
+
+# Dative App helper functions
+
+DEFAULT_DATIVE_APP_URL = 'http://127.0.0.1:5678'
+
+
+def get_dative_app():
+    now = get_now()
+    try:
+        return DBSession.query(DativeApp).filter(DativeApp.end > now).one()
+    except NoResultFound:
+        pass
+    except MultipleResultsFound:
+        for app in DBSession.query(DativeApp).filter(DativeApp.end > now).all():
+            app.end = now
+            DBSession.add(app)
+    app = DativeApp(url=DEFAULT_DATIVE_APP_URL)
+    DBSession.add(app)
+    DBSession.flush()
+    return app
+
+
+def update_dative_app(url):
+    app = get_dative_app()
+    now = get_now()
+    app.end = now
+    new_app = DativeApp(url=url,
+                        history_id=app.history_id,
+                        start=now)
+    DBSession.add(app)
+    DBSession.add(new_app)
+    DBSession.flush()
+    return new_app
+
+
+# OLD Service App helper functions
+
+DEFAULT_OLD_SERVICE_URL = 'http://127.0.0.1:5679'
+
+
+def get_old_service():
+    now = get_now()
+    try:
+        return DBSession.query(OLDService).filter(OLDService.end > now).one()
+    except NoResultFound:
+        pass
+    except MultipleResultsFound:
+        for old_service in DBSession.query(OLDService).filter(OLDService.end > now).all():
+            old_service.end = now
+            DBSession.add(old_service)
+    old_service = OLDService(url=DEFAULT_OLD_SERVICE_URL)
+    DBSession.add(old_service)
+    DBSession.flush()
+    return old_service
+
+
+def update_old_service(url):
+    old_service = get_old_service()
+    now = get_now()
+    old_service.end = now
+    new_old_service = OLDService(url=url,
+                                 history_id=old_service.history_id,
+                                 start=now)
+    DBSession.add(old_service)
+    DBSession.add(new_old_service)
+    DBSession.flush()
+    return new_old_service
+
+
+# OLD helper functions
+
+def create_old(slug, name=None, leader=None, username=None, password=None,
+               is_auto_syncing=False):
+    existing_old = DBSession.query(OLD).filter(
+        OLD.slug == slug,
+        OLD.end > get_now()).first()
+    if existing_old:
+        raise ValueError('Slug already in use')
+    name = name or slug
+    old = OLD(slug=slug,
+              name=name,
+              leader=leader,
+              username=username,
+              password=password,
+              is_auto_syncing=is_auto_syncing)
+    DBSession.add(old)
+    DBSession.flush()
+    return old
+
+
+def update_old(old, **kwargs):
+    now = get_now()
+    if old.end < now:
+        raise ValueError('Cannot update an inactive OLD')
+    old.end = now
+    new_kwargs = {'history_id': old.history_id,
+                  'start': now}
+    for attr in ['slug', 'name', 'leader', 'username', 'password',
+                 'state', 'is_auto_syncing']:
+        new_kwargs[attr] = kwargs.get(attr, getattr(old, attr))
+    new_old = OLD(**new_kwargs)
+    DBSession.add(old)
+    DBSession.add(new_old)
+    DBSession.flush()
+    return new_old
+
+
+def transition_old(old, state):
+    now = get_now()
+    if old.end < now:
+        raise ValueError('Cannot transition an inactive OLD')
+    old.end = now
+    new_kwargs = {'history_id': old.history_id,
+                  'start': now,
+                  'state': state}
+    for attr in ['slug', 'name', 'leader', 'username', 'password',
+                 'is_auto_syncing']:
+        new_kwargs[attr] = getattr(old, attr)
+    new_old = OLD(**new_kwargs)
+    DBSession.add(old)
+    DBSession.add(new_old)
+    DBSession.flush()
+    return new_old
+
+
+def delete_old(old):
+    old.end = get_now()
+    DBSession.add(old)
+    DBSession.flush()
+    return old
+
+
+def get_old(history_id):
+    now = get_now()
+    old = DBSession.query(OLD).filter(
+        OLD.history_id == history_id,
+        OLD.end > now
+    ).one()
+    return old
+
+
+def get_olds():
+    now = get_now()
+    olds = DBSession.query(OLD).filter(
+        OLD.end > now
+    ).all()
+    return olds
+
+
+# Command helper functions
+
+# Command state machine: enqueued -> acked -> complete
+# enqueued: c.acked = False (active)
+# acked:    c.acked = True  (active)
+# complete: c.end   < now
+
+def enqueue_sync_old_command(old_id):
+    """Enqueue a sync-OLD! command."""
+    now = get_now()
+    existing_command = DBSession.query(SyncOLDCommand).filter(
+        SyncOLDCommand.end > now,
+        SyncOLDCommand.old_id == old_id,
+    ).first()
+    if existing_command:
+        return existing_command
+    command = SyncOLDCommand(old_id=old_id) # enqueued
+    DBSession.add(command)
+    DBSession.flush()
+    return command
+
+
+def get_sync_old_command(sync_old_command_id):
+    """Get the sync-OLD! with the provided ID."""
+    now = get_now()
+    command = DBSession.query(SyncOLDCommand).filter(
+        SyncOLDCommand.history_id == sync_old_command_id,
+        SyncOLDCommand.end > now
+    ).one()
+    return command
+
+
+def pop_sync_old_command():
+    """Get the next sync-OLD! command that needs to be run, or ``None`` if there
+    aren't any. Pop it from the end of the queue by acknowledging it."""
+    now = get_now()
+    next_command = DBSession.query(SyncOLDCommand).filter(
+        SyncOLDCommand.end > now,
+        SyncOLDCommand.acked.is_(False)
+    ).order_by(
+        asc(SyncOLDCommand.start)
+    ).first()
+    if not next_command:
+        return None
+    next_command.end = now
+    new_kwargs = {'history_id': next_command.history_id,
+                  'old_id': next_command.old_id,
+                  'acked': True,}
+    new_next_command = SyncOLDCommand(**new_kwargs)
+    DBSession.add(next_command)
+    DBSession.add(new_next_command)
+    DBSession.flush()
+    return new_next_command
+
+
+def complete_sync_old_command(sync_old_command_id):
+    """Update the acked sync-OLD! command to mark it as completed."""
+    now = get_now()
+    command = DBSession.query(SyncOLDCommand).filter(
+        SyncOLDCommand.history_id == sync_old_command_id,
+        SyncOLDCommand.end > now,
+        SyncOLDCommand.acked.is_(True)
+    ).one()
+    command.end = now
+    DBSession.add(command)
+    DBSession.flush()
+    return command

--- a/src/dativetop/server/dativetopserver/views.py
+++ b/src/dativetop/server/dativetopserver/views.py
@@ -7,13 +7,6 @@ import sys
 from wsgiref.simple_server import make_server
 from pyramid.config import Configurator
 
-# import dativetopserver.aol as aol
-import dtaoldm.aol as aol_mod
-
-
-AOL_PATH = 'aol.txt'
-
-
 logging_config = dict(
     version=1,
     formatters={

--- a/src/dativetop/server/setup.py
+++ b/src/dativetop/server/setup.py
@@ -12,7 +12,10 @@ requires = [
     'pyramid',
     'pyramid_chameleon',
     'pyramid_debugtoolbar',
+    'pyramid_tm',
+    'sqlalchemy',
     'waitress',
+    'zope.sqlalchemy',
     ]
 
 tests_require = [
@@ -21,29 +24,34 @@ tests_require = [
     'pytest-cov',
     ]
 
-setup(name='dativetopserver',
-      version='0.0',
-      description='dativetopserver',
-      long_description=README + '\n\n' + CHANGES,
-      classifiers=[
-          "Programming Language :: Python",
-          "Framework :: Pyramid",
-          "Topic :: Internet :: WWW/HTTP",
-          "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
-      ],
-      author='',
-      author_email='',
-      url='',
-      keywords='web pyramid pylons',
-      packages=find_packages(),
-      include_package_data=True,
-      zip_safe=False,
-      extras_require={
-          'testing': tests_require,
-      },
-      install_requires=requires,
-      entry_points="""\
-      [paste.app_factory]
-      main = dativetopserver:main
-      """,
-      )
+setup(
+    name='dativetopserver',
+    version='0.0',
+    description='dativetopserver',
+    long_description=README + '\n\n' + CHANGES,
+    classifiers=[
+        "Programming Language :: Python",
+        "Framework :: Pyramid",
+        "Topic :: Internet :: WWW/HTTP",
+        "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
+    ],
+    author='',
+    author_email='',
+    url='',
+    keywords='web pyramid pylons',
+    packages=find_packages(),
+    include_package_data=True,
+    zip_safe=False,
+    extras_require={
+        'testing': tests_require,
+    },
+    install_requires=requires,
+    entry_points={
+        'paste.app_factory': [
+            'main = dativetopserver:main'
+        ],
+        'console_scripts': [
+            'initialize_dtserver_db = dativetopserver.initialize_db:main'
+        ],
+    }
+)

--- a/src/dativetop/server/tests/test_aol.py
+++ b/src/dativetop/server/tests/test_aol.py
@@ -4,7 +4,7 @@
 import os
 from pathlib import Path
 
-import dativetop.aol as aol_mod
+import dativetopserver.aol as aol_mod
 import tests.utils as utils
 
 

--- a/src/dativetop/server/tests/test_aol_performance.py
+++ b/src/dativetop/server/tests/test_aol_performance.py
@@ -67,7 +67,7 @@ import time
 
 import pytest
 
-import dativetop.aol as aol_mod
+import dativetopserver.aol as aol_mod
 import tests.utils as utils
 
 

--- a/src/dativetop/server/tests/test_domain.py
+++ b/src/dativetop/server/tests/test_domain.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-import dativetop.domain as domain
+import dativetopserver.domain as domain
 import tests.utils as utils
 
 

--- a/src/dativetop/server/tests/test_domain_aol.py
+++ b/src/dativetop/server/tests/test_domain_aol.py
@@ -1,8 +1,8 @@
 """Tests for storing domain entities in the append-only log
 """
 
-import dativetop.domain as domain
-import dativetop.aol as aol_mod
+import dativetopserver.domain as domain
+import dativetopserver.aol as aol_mod
 
 
 def generate_test_aol():

--- a/src/dativetop/server/tests/test_models.py
+++ b/src/dativetop/server/tests/test_models.py
@@ -1,0 +1,228 @@
+import unittest
+import transaction
+
+from pyramid import testing
+
+
+def _initTestingDB():
+    from sqlalchemy import create_engine
+    from dativetopserver.models import (
+        Base,
+        DativeApp,
+        DBSession,
+        OLD,
+        OLDService,
+        SyncOLDCommand,
+    )
+    engine = create_engine('sqlite://')
+    Base.metadata.create_all(engine)
+    DBSession.configure(bind=engine)
+    return DBSession
+
+
+class ModelsTests(unittest.TestCase):
+    def setUp(self):
+        self.session = _initTestingDB()
+        self.config = testing.setUp()
+
+    def tearDown(self):
+        self.session.remove()
+        testing.tearDown()
+
+    def test_dative_app_api(self):
+        import dativetopserver.models as m
+        self.assertEqual([], self.session.query(m.DativeApp).all())
+        app = m.get_dative_app()
+        self.assertEqual([app], self.session.query(m.DativeApp).all())
+        updated_app = m.update_dative_app('app-url-updated')
+        final_url = 'http://localhost:5679'
+        finalized_app = m.update_dative_app(final_url)
+        apps = self.session.query(m.DativeApp).all()
+        now = m.get_now()
+        self.assertEqual(3, len(set([a.url for a in apps])),
+                         'expected 3 distinct app URLs')
+        self.assertEqual(3, len(set([a.uuid for a in apps])),
+                         'expected 3 distinct app IDs')
+        self.assertEqual(1, len([a for a in apps if a.end > now]),
+                         'expected 1 active app')
+        self.assertEqual(2, len([a for a in apps if a.end < now]),
+                         'expected 2 inactive apps')
+        self.assertEqual(final_url, [a for a in apps if a.end > now][0].url,
+                         'expected final URL for active app')
+        self.assertEqual(final_url, finalized_app.url,
+                         'expected final URL for returned active app')
+
+    def test_old_service_api(self):
+        import dativetopserver.models as m
+        self.assertEqual([], self.session.query(m.OLDService).all())
+        old_service = m.get_old_service()
+        self.assertEqual([old_service], self.session.query(m.OLDService).all())
+        updated_old_service = m.update_old_service('service-url-updated')
+        final_url = 'http://localhost:5673'
+        finalized_old_service = m.update_old_service(final_url)
+        old_services = self.session.query(m.OLDService).all()
+        now = m.get_now()
+        self.assertEqual(3, len(set([a.url for a in old_services])),
+                         'expected 3 distinct old service URLs')
+        self.assertEqual(3, len(set([a.uuid for a in old_services])),
+                         'expected 3 distinct old service IDs')
+        self.assertEqual(1, len([a for a in old_services if a.end > now]),
+                         'expected 1 active old service')
+        self.assertEqual(2, len([a for a in old_services if a.end < now]),
+                         'expected 2 inactive old service')
+        self.assertEqual(final_url, [a for a in old_services if a.end > now][0].url,
+                         'expected final URL for active old service')
+        self.assertEqual(final_url, finalized_old_service.url,
+                         'expected final URL for returned active old service')
+
+    def test_old_api(self):
+        import dativetopserver.models as m
+        from sqlalchemy.orm.exc import NoResultFound
+        self.assertEqual([], self.session.query(m.OLD).all())
+
+        # Create an initial OLD, supplying just the slug
+        old1 = m.create_old('oka')
+        old_service = m.get_old_service()
+        self.assertEqual('oka', old1.slug)
+        self.assertEqual('oka', old1.name)
+        self.assertIsNone(old1.leader)
+        self.assertIsNone(old1.username)
+        self.assertIsNone(old1.password)
+        self.assertFalse(old1.is_auto_syncing)
+        self.assertEqual(m.old_state.not_synced, old1.state)
+
+        # Create a second OLD, supplying everything
+        old2 = m.create_old('bla',
+                           name='Blackfoot',
+                           leader='https://do.onlinelinguisticdatabase.org/blaold',
+                           username='someuser',
+                           password='somepassword',
+                           is_auto_syncing=True)
+        self.assertEqual('bla', old2.slug)
+        self.assertEqual('Blackfoot', old2.name)
+        self.assertEqual('https://do.onlinelinguisticdatabase.org/blaold',
+                         old2.leader)
+        self.assertEqual('someuser', old2.username)
+        self.assertEqual('somepassword', old2.password)
+        self.assertTrue(old2.is_auto_syncing)
+        old2_history_id = old2.history_id
+
+        # Update the second OLD
+        new_old2 = m.update_old(old2, leader='abc')
+        self.assertEqual('abc', new_old2.leader)
+        for attr in ['slug', 'name', 'username', 'password', 'is_auto_syncing']:
+            self.assertEqual(getattr(old2, attr), getattr(new_old2, attr))
+        olds = self.session.query(m.OLD).all()
+        self.assertEqual(3, len(olds))
+        self.assertEqual(2, len([o for o in olds if o.end > m.get_now()]))
+        self.assertEqual(2, len(m.get_olds()))
+        self.assertEqual(new_old2, m.get_old(old2_history_id))
+
+        # Attempting to create an OLD with the slug of an existing OLD will throw
+        try:
+            m.create_old(new_old2.slug)
+        except Exception as e:
+            self.assertIsInstance(e, ValueError)
+
+        # Delete the second OLD
+        deleted_old2 = m.delete_old(new_old2)
+        self.assertGreater(m.get_now(), deleted_old2.end)
+        self.assertEqual(1, len(m.get_olds()))
+        try:
+            m.get_old(old2_history_id)
+        except Exception as e:
+            self.assertIsInstance(e, NoResultFound)
+
+        # After deleting the second OLD, we can reuse its slug.
+        # Let's transition it through some plausible state transitions.
+        blaold = m.create_old(new_old2.slug)
+        self.assertEqual(m.old_state.not_synced,
+                         m.get_old(blaold.history_id).state)
+        blaold_syncing = m.transition_old(blaold, m.old_state.syncing)
+        self.assertEqual(m.old_state.syncing,
+                         m.get_old(blaold.history_id).state)
+        blaold_synced = m.transition_old(blaold_syncing, m.old_state.synced)
+        self.assertEqual(m.old_state.synced,
+                         m.get_old(blaold.history_id).state)
+        blaold_not_synced = m.transition_old(blaold_synced,
+                                             m.old_state.not_synced)
+        self.assertEqual(m.old_state.not_synced,
+                         m.get_old(blaold.history_id).state)
+
+        # We cannot transition a deactivated OLD
+        try:
+            m.transition_old(blaold_synced, m.old_state.not_synced)
+        except Exception as e:
+            self.assertIsInstance(e, ValueError)
+
+        # Transition a new OLD through a "sync failed" flow
+        zinc_old = m.create_old('zinc')
+        self.assertEqual(m.old_state.not_synced,
+                         m.get_old(zinc_old.history_id).state)
+        zinc_old_syncing = m.transition_old(zinc_old, m.old_state.syncing)
+        self.assertEqual(m.old_state.syncing,
+                         m.get_old(zinc_old.history_id).state)
+        zinc_old_failed_to_sync = m.transition_old(
+            zinc_old_syncing, m.old_state.failed_to_sync)
+        self.assertEqual(m.old_state.failed_to_sync,
+                         m.get_old(zinc_old.history_id).state)
+        zinc_old_not_synced = m.transition_old(zinc_old_failed_to_sync,
+                                               m.old_state.not_synced)
+        self.assertEqual(m.old_state.not_synced,
+                         m.get_old(zinc_old.history_id).state)
+
+    def test_sync_old_command_api(self):
+        import dativetopserver.models as m
+        from sqlalchemy.orm.exc import NoResultFound
+
+        # The queue is initially empty
+        self.assertIsNone(m.pop_sync_old_command())
+
+        # Create 3 OLDs and a sync command for the second.
+        old1 = m.create_old('one')
+        old2 = m.create_old('two')
+        old3 = m.create_old('three')
+        cmd1 = m.enqueue_sync_old_command(old2.history_id)
+        self.assertFalse(cmd1.acked)
+        self.assertGreater(cmd1.end, m.get_now())
+        self.assertEqual(cmd1.old_id, old2.history_id)
+        self.assertIs(cmd1, m.get_sync_old_command(cmd1.history_id))
+
+        # Trying to enqueue a sync command for the same OLD again will just
+        # return the existing active command.
+        cmd1_clone = m.enqueue_sync_old_command(old2.history_id)
+        self.assertIs(cmd1, cmd1_clone)
+
+        # Let's pop the command, expecting that to ACK it
+        acked_cmd1 = m.pop_sync_old_command()
+        self.assertTrue(acked_cmd1.acked)
+        self.assertGreater(acked_cmd1.end, m.get_now())
+        self.assertEqual(acked_cmd1.old_id, old2.history_id)
+        self.assertIsNone(m.pop_sync_old_command())
+
+        # Trying to enqueue a sync command for the same OLD again will again
+        # just return the existing active acked command.
+        cmd1_clone2 = m.enqueue_sync_old_command(old2.history_id)
+        self.assertIs(acked_cmd1, cmd1_clone2)
+
+        # Pretend we're a worker marking the command as complete
+        completed_cmd1 = m.complete_sync_old_command(acked_cmd1.history_id)
+        self.assertLess(acked_cmd1.end, m.get_now())
+
+        # Create three commands and expect to pop them in FIFO order
+        m.enqueue_sync_old_command(old2.history_id)
+        m.enqueue_sync_old_command(old3.history_id)
+        cmd = m.enqueue_sync_old_command(old1.history_id)
+        self.assertEqual(old2.history_id, m.pop_sync_old_command().old_id)
+        self.assertEqual(old3.history_id, m.pop_sync_old_command().old_id)
+        self.assertEqual(old1.history_id, m.pop_sync_old_command().old_id)
+        self.assertIsNone(m.pop_sync_old_command())
+
+        # Cannot get a completed command
+        self.assertEqual(cmd.history_id,
+                         m.get_sync_old_command(cmd.history_id).history_id)
+        m.complete_sync_old_command(cmd.history_id)
+        try:
+            m.get_sync_old_command(cmd.history_id)
+        except Exception as e:
+            self.assertIsInstance(e, NoResultFound)

--- a/src/dativetop/server/tests/utils.py
+++ b/src/dativetop/server/tests/utils.py
@@ -4,8 +4,8 @@
 from collections import namedtuple
 import os
 
-import dativetop.aol as aol_mod
-import dativetop.domain as domain
+import dativetopserver.aol as aol_mod
+import dativetopserver.domain as domain
 
 
 HERE = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Addresses https://github.com/dativebase/dativetop/issues/11

## Problem

We want DTServer to be an HTTP API for managing the DativeTop state. The entities/resources to be managed are the local Dative app, the local OLD service, a collection of OLD instances, and a queue of `sync-OLD!` commands.

## Changes

- Add SQLite models
  - Add `models.py` module with classes and APIs for `DativeApp`, `OLDService`, `OLD`,
    and `SyncOLDCommand`.
  - Add `initialize_dtserver_db` console script to create DB tables.
  - Add db integration tests for model API behaviour.
  - Add SQLAlchemy dependency and boilerplate.
  - Remove `dtaoldm` import from `views.py`.
  - Change `dativetop` to `dativetopserver` in all test modules.
  - Add to README explaining how to run the tests.