### PR TITLE
Add OLDService endpoints

### DIFF
--- a/src/dativetop/server/dativetopserver/models.py
+++ b/src/dativetop/server/dativetopserver/models.py
@@ -77,7 +77,7 @@ class OLD(Base):
     __tablename__ = 'old'
     uuid = Column(String(length=36), primary_key=True, default=gen_uuid)
     history_id = Column(String(length=36), default=gen_uuid, index=True)
-    # unique among OLD instances at a given OLDService.url, e.g., "oka"
+    # suffixed to the URL of the local OLDService.url, e.g., "oka"
     slug = Column(Unicode(length=256), nullable=False, index=True)
     # human readable name, e.g., "Okanagan"
     name = Column(Unicode(length=256), nullable=False)
@@ -144,6 +144,11 @@ def update_dative_app(url):
 DEFAULT_OLD_SERVICE_URL = 'http://127.0.0.1:5679'
 
 
+def serialize_old_service(old_service):
+    return {'id': old_service.history_id,
+            'url': old_service.url}
+
+
 def get_old_service():
     now = get_now()
     try:
@@ -151,7 +156,8 @@ def get_old_service():
     except NoResultFound:
         pass
     except MultipleResultsFound:
-        for old_service in DBSession.query(OLDService).filter(OLDService.end > now).all():
+        for old_service in DBSession.query(OLDService).filter(
+                OLDService.end > now).all():
             old_service.end = now
             DBSession.add(old_service)
     old_service = OLDService(url=DEFAULT_OLD_SERVICE_URL)

--- a/src/dativetop/server/tests/test_views.py
+++ b/src/dativetop/server/tests/test_views.py
@@ -1,0 +1,49 @@
+import transaction
+import unittest
+
+from pyramid import testing
+
+
+def _initTestingDB():
+    from sqlalchemy import create_engine
+    from dativetopserver.models import (Base, DBSession)
+    engine = create_engine('sqlite://')
+    Base.metadata.create_all(engine)
+    DBSession.configure(bind=engine)
+    return DBSession
+
+
+class ViewsTests(unittest.TestCase):
+
+    def setUp(self):
+        self.session = _initTestingDB()
+        self.config = testing.setUp()
+
+    def tearDown(self):
+        self.session.remove()
+        testing.tearDown()
+
+    def test_old_service_api(self):
+        import dativetopserver.views as v
+        import dativetopserver.models as m
+        self.assertEqual([], self.session.query(m.OLDService).all())
+        request = testing.DummyRequest(method='GET')
+        response = v.old_service(request)
+        self.assertEqual(1, len(self.session.query(m.OLDService).all()))
+        self.assertEqual(m.DEFAULT_OLD_SERVICE_URL, response['url'])
+        request = testing.DummyRequest(
+            json_body={'url': 'dog'}, method='PUT')
+        response = v.old_service(request)
+        self.assertEqual(2, len(self.session.query(m.OLDService).all()))
+        self.assertEqual('dog', response['url'])
+        request = testing.DummyRequest(
+            json_body={'url': 'dog'}, method='POST')
+        response = v.old_service(request)
+        self.assertEqual(
+            'The old_service only recognizes GET and PUT requests.',
+            response['error'])
+        v.old_service(testing.DummyRequest(json_body={'url': 'cat'},
+                                           method='PUT'))
+        old_service_rows = self.session.query(m.OLDService).all()
+        self.assertEqual(3, len(old_service_rows))
+        self.assertEqual(1, len(set([os.history_id for os in old_service_rows])))

--- a/src/dativetop/server/tests/test_views.py
+++ b/src/dativetop/server/tests/test_views.py
@@ -31,19 +31,34 @@ class ViewsTests(unittest.TestCase):
         response = v.old_service(request)
         self.assertEqual(1, len(self.session.query(m.OLDService).all()))
         self.assertEqual(m.DEFAULT_OLD_SERVICE_URL, response['url'])
+        new_url = 'http://localhost:1111'
         request = testing.DummyRequest(
-            json_body={'url': 'dog'}, method='PUT')
+            json_body={'url': new_url}, method='PUT')
         response = v.old_service(request)
         self.assertEqual(2, len(self.session.query(m.OLDService).all()))
-        self.assertEqual('dog', response['url'])
+        self.assertEqual(new_url, response['url'])
+        new_new_url = 'http://localhost:2222'
         request = testing.DummyRequest(
-            json_body={'url': 'dog'}, method='POST')
+            json_body={'url': new_new_url}, method='POST')
         response = v.old_service(request)
         self.assertEqual(
             'The old_service only recognizes GET and PUT requests.',
             response['error'])
-        v.old_service(testing.DummyRequest(json_body={'url': 'cat'},
+        v.old_service(testing.DummyRequest(json_body={'url': new_new_url},
                                            method='PUT'))
         old_service_rows = self.session.query(m.OLDService).all()
         self.assertEqual(3, len(old_service_rows))
         self.assertEqual(1, len(set([os.history_id for os in old_service_rows])))
+
+    def test_old_service_url_validation(self):
+        import dativetopserver.views as v
+        self.assertEqual('scheme is not http',
+                         v.validate_old_service_url('https://localhost:1111'))
+        self.assertEqual('no port',
+                         v.validate_old_service_url('http://localhost'))
+        self.assertIn('hostname invalid',
+                      v.validate_old_service_url('http://myhost:1111'))
+        self.assertEqual('path is not empty',
+                      v.validate_old_service_url('http://127.0.0.1:1111/foo'))
+        self.assertIsNone(v.validate_old_service_url('http://127.0.0.1:1111/'))
+        self.assertIsNone(v.validate_old_service_url('http://localhost:5678'))


### PR DESCRIPTION
Resolves https://github.com/dativebase/dativetop/issues/15

## Changes

- Add /old_service endpoint
  - GET request returns *the* OLD Service
  - PUT request allows for the URL to be modified
  - OLDService.url input validation
  - Tests
