### PR TITLE
Add Dative App endpoint

### DIFF
--- a/src/dativetop/server/dativetopserver/models.py
+++ b/src/dativetop/server/dativetopserver/models.py
@@ -110,6 +110,11 @@ class SyncOLDCommand(Base):
 DEFAULT_DATIVE_APP_URL = 'http://127.0.0.1:5678'
 
 
+def serialize_dative_app(dative_app):
+    return {'id': dative_app.history_id,
+            'url': dative_app.url}
+
+
 def get_dative_app():
     now = get_now()
     try:

--- a/src/dativetop/server/dativetopserver/views.py
+++ b/src/dativetop/server/dativetopserver/views.py
@@ -147,7 +147,11 @@ def update_old_service(request):
     if validation_error:
         request.response.status = 400
         return {'error': validation_error}
-    updated_old_service = m.update_old_service(url.rstrip('/'))
+    url = url.rstrip('/')
+    dative_app_url = m.get_dative_app().url.rstrip('/')
+    if url == dative_app_url:
+        return {'error': 'OLD Service URL must be different from Dative App URL'}
+    updated_old_service = m.update_old_service(url)
     return m.serialize_old_service(updated_old_service)
 
 
@@ -192,7 +196,11 @@ def update_dative_app(request):
     if validation_error:
         request.response.status = 400
         return {'error': validation_error}
-    updated_dative_app = m.update_dative_app(url.rstrip('/'))
+    url = url.rstrip('/')
+    old_service_url = m.get_old_service().url.rstrip('/')
+    if url == old_service_url:
+        return {'error': 'Dative App URL must be different from OLD Service URL'}
+    updated_dative_app = m.update_dative_app(url)
     return m.serialize_dative_app(updated_dative_app)
 
 

--- a/src/dativetop/server/tests/test_views.py
+++ b/src/dativetop/server/tests/test_views.py
@@ -49,6 +49,11 @@ class ViewsTests(unittest.TestCase):
         old_service_rows = self.session.query(m.OLDService).all()
         self.assertEqual(3, len(old_service_rows))
         self.assertEqual(1, len(set([os.history_id for os in old_service_rows])))
+        request = testing.DummyRequest(
+            json_body={'url': m.get_dative_app().url}, method='PUT')
+        response = v.old_service(request)
+        self.assertEqual('OLD Service URL must be different from Dative App URL',
+                         response['error'])
 
     def test_dative_app_api(self):
         import dativetopserver.views as v
@@ -76,6 +81,12 @@ class ViewsTests(unittest.TestCase):
         dative_app_rows = self.session.query(m.DativeApp).all()
         self.assertEqual(3, len(dative_app_rows))
         self.assertEqual(1, len(set([os.history_id for os in dative_app_rows])))
+        request = testing.DummyRequest(
+            json_body={'url': m.get_old_service().url}, method='PUT')
+        response = v.dative_app(request)
+        self.assertEqual('Dative App URL must be different from OLD Service URL',
+                         response['error'])
+
 
     def test_local_url_validation(self):
         import dativetopserver.views as v

--- a/src/dativetop/server/tests/test_views.py
+++ b/src/dativetop/server/tests/test_views.py
@@ -42,7 +42,7 @@ class ViewsTests(unittest.TestCase):
             json_body={'url': new_new_url}, method='POST')
         response = v.old_service(request)
         self.assertEqual(
-            'The old_service only recognizes GET and PUT requests.',
+            'The old_service endpoint only recognizes GET and PUT requests.',
             response['error'])
         v.old_service(testing.DummyRequest(json_body={'url': new_new_url},
                                            method='PUT'))
@@ -50,15 +50,42 @@ class ViewsTests(unittest.TestCase):
         self.assertEqual(3, len(old_service_rows))
         self.assertEqual(1, len(set([os.history_id for os in old_service_rows])))
 
-    def test_old_service_url_validation(self):
+    def test_dative_app_api(self):
+        import dativetopserver.views as v
+        import dativetopserver.models as m
+        self.assertEqual([], self.session.query(m.DativeApp).all())
+        request = testing.DummyRequest(method='GET')
+        response = v.dative_app(request)
+        self.assertEqual(1, len(self.session.query(m.DativeApp).all()))
+        self.assertEqual(m.DEFAULT_DATIVE_APP_URL, response['url'])
+        new_url = 'http://localhost:1111'
+        request = testing.DummyRequest(
+            json_body={'url': new_url}, method='PUT')
+        response = v.dative_app(request)
+        self.assertEqual(2, len(self.session.query(m.DativeApp).all()))
+        self.assertEqual(new_url, response['url'])
+        new_new_url = 'http://localhost:2222'
+        request = testing.DummyRequest(
+            json_body={'url': new_new_url}, method='POST')
+        response = v.dative_app(request)
+        self.assertEqual(
+            'The dative_app endpoint only recognizes GET and PUT requests.',
+            response['error'])
+        v.dative_app(testing.DummyRequest(json_body={'url': new_new_url},
+                                           method='PUT'))
+        dative_app_rows = self.session.query(m.DativeApp).all()
+        self.assertEqual(3, len(dative_app_rows))
+        self.assertEqual(1, len(set([os.history_id for os in dative_app_rows])))
+
+    def test_local_url_validation(self):
         import dativetopserver.views as v
         self.assertEqual('scheme is not http',
-                         v.validate_old_service_url('https://localhost:1111'))
+                         v.validate_local_url('https://localhost:1111'))
         self.assertEqual('no port',
-                         v.validate_old_service_url('http://localhost'))
+                         v.validate_local_url('http://localhost'))
         self.assertIn('hostname invalid',
-                      v.validate_old_service_url('http://myhost:1111'))
+                      v.validate_local_url('http://myhost:1111'))
         self.assertEqual('path is not empty',
-                      v.validate_old_service_url('http://127.0.0.1:1111/foo'))
-        self.assertIsNone(v.validate_old_service_url('http://127.0.0.1:1111/'))
-        self.assertIsNone(v.validate_old_service_url('http://localhost:5678'))
+                      v.validate_local_url('http://127.0.0.1:1111/foo'))
+        self.assertIsNone(v.validate_local_url('http://127.0.0.1:1111/'))
+        self.assertIsNone(v.validate_local_url('http://localhost:5678'))


### PR DESCRIPTION
## Rationale

Addresses https://github.com/dativebase/dativetop/issues/16.

## Changes

- Add /dative_app endpoint
  - GET request returns *the* Dative App
  - PUT request allows for the URL to be modified
  - Tests
- Enforce distinct OLD Service and Dative App URLs