### PR TITLE
Add endpoints for OLD resource:

### DIFF
--- a/src/dativetop/server/tests/test_models.py
+++ b/src/dativetop/server/tests/test_models.py
@@ -122,7 +122,7 @@ class ModelsTests(unittest.TestCase):
         try:
             m.create_old(new_old2.slug)
         except Exception as e:
-            self.assertIsInstance(e, ValueError)
+            self.assertIsInstance(e, m.DTValueError)
 
         # Delete the second OLD
         deleted_old2 = m.delete_old(new_old2)
@@ -153,7 +153,7 @@ class ModelsTests(unittest.TestCase):
         try:
             m.transition_old(blaold_synced, m.old_state.not_synced)
         except Exception as e:
-            self.assertIsInstance(e, ValueError)
+            self.assertIsInstance(e, m.DTValueError)
 
         # Transition a new OLD through a "sync failed" flow
         zinc_old = m.create_old('zinc')

--- a/src/dativetop/server/tests/test_views.py
+++ b/src/dativetop/server/tests/test_views.py
@@ -1,7 +1,15 @@
 import transaction
 import unittest
+from uuid import uuid4
 
 from pyramid import testing
+from sqlalchemy import desc
+
+
+def is_uuid_str(x):
+    return (isinstance(x, str) and
+            [8, 4, 4, 4, 12] == [len([c for c in y if c in '0123456789abcdef'])
+                                 for y in x.split('-')])
 
 
 def _initTestingDB():
@@ -42,7 +50,7 @@ class ViewsTests(unittest.TestCase):
             json_body={'url': new_new_url}, method='POST')
         response = v.old_service(request)
         self.assertEqual(
-            'The old_service endpoint only recognizes GET and PUT requests.',
+            'The /old_service endpoint only recognizes GET and PUT requests.',
             response['error'])
         v.old_service(testing.DummyRequest(json_body={'url': new_new_url},
                                            method='PUT'))
@@ -74,7 +82,7 @@ class ViewsTests(unittest.TestCase):
             json_body={'url': new_new_url}, method='POST')
         response = v.dative_app(request)
         self.assertEqual(
-            'The dative_app endpoint only recognizes GET and PUT requests.',
+            'The /dative_app endpoint only recognizes GET and PUT requests.',
             response['error'])
         v.dative_app(testing.DummyRequest(json_body={'url': new_new_url},
                                            method='PUT'))
@@ -100,3 +108,156 @@ class ViewsTests(unittest.TestCase):
                       v.validate_local_url('http://127.0.0.1:1111/foo'))
         self.assertIsNone(v.validate_local_url('http://127.0.0.1:1111/'))
         self.assertIsNone(v.validate_local_url('http://localhost:5678'))
+
+
+    def test_create_old(self):
+        import dativetopserver.views as v
+        import dativetopserver.models as m
+        self.assertEqual([], self.session.query(m.OLD).all())
+        request = testing.DummyRequest(
+            method='POST',
+            json_body={'slug': 'oka'})
+        response = v.olds(request)
+        self.assertEqual(1, len(self.session.query(m.OLD).all()))
+        self.assertEqual('oka', response['slug'])
+        self.assertEqual('oka', response['name'])
+        self.assertEqual([None, None, None, False],
+                         [response['leader'], response['username'],
+                          response['password'], response['is_auto_syncing']])
+
+        # Valid OLD Creation
+        valid_input = {
+            'slug': 'bla',
+            'name': 'Blackfoot',
+            'leader': 'https://do.old.org/bla',
+            'username': 'someuser',
+            'password': 'somepassword',
+            'is_auto_syncing': True
+        }
+        request = testing.DummyRequest(
+            method='POST', json_body=valid_input)
+        response = v.olds(request)
+        self.assertEqual(2, len(self.session.query(m.OLD).all()))
+        for attr, val in valid_input.items():
+            self.assertEqual(val, response[attr])
+        self.assertTrue(is_uuid_str(response['id']), 'OLD.id is a UUID')
+
+        # Invalid OLD Creation 1: is_auto_syncing not boolean
+        invalid_input = valid_input.copy()
+        invalid_input['slug'] = 'invalidbla'
+        invalid_input['is_auto_syncing'] = 1
+        response = v.olds(
+            testing.DummyRequest(method='POST', json_body=invalid_input))
+        self.assertEqual(2, len(self.session.query(m.OLD).all()))
+        self.assertEqual('value must be a boolean', response['error'])
+
+        # Invalid OLD Creation 2: leader not string
+        invalid_input = valid_input.copy()
+        invalid_input['slug'] = 'invalidbla'
+        invalid_input['leader'] = 1
+        response = v.olds(
+            testing.DummyRequest(method='POST', json_body=invalid_input))
+        self.assertEqual(2, len(self.session.query(m.OLD).all()))
+        self.assertEqual('value must be a string', response['error'])
+
+        # Fetch the created OLDs via the API
+        response = v.olds(testing.DummyRequest(method='GET'))
+        self.assertEqual(2, len(response))
+        self.assertEqual(set(['oka', 'bla']),
+                         set([o['slug'] for o in response]))
+
+        # Fetch the first created OLD via the API
+        old = response[0]
+        old_id = old['id']
+        response = v.old(testing.DummyRequest(method='GET',
+                                              matchdict={'old_id': old_id}))
+        self.assertEqual(old, response)
+
+        # Fail to fetch an OLD using an invalid ID
+        response = v.old(testing.DummyRequest(method='GET',
+                                              matchdict={'old_id': str(uuid4())}))
+        self.assertEqual('No OLD with supplied ID', response['error'])
+
+        # Update the first OLD
+        valid_input = {
+            'name': 'Okanagan',
+            'leader': 'https://do.old.org/oka',
+            'username': 'someuser',
+            'password': 'somepassword',
+            'is_auto_syncing': True
+        }
+        request = testing.DummyRequest(
+            method='PUT', json_body=valid_input, matchdict={'old_id': old_id})
+        response = v.old(request)
+        self.assertEqual(3, len(self.session.query(m.OLD).all())) # history retained
+        self.assertEqual(2, len(v.olds(testing.DummyRequest(method='GET'))))
+        for attr, val in valid_input.items():
+            self.assertEqual(val, response[attr])
+        self.assertEqual(old_id, response['id'])
+
+        # Updates to slug and state silently fail
+        vacuous_input = {'slug': 'okana', 'state': m.old_state.failed_to_sync}
+        request = testing.DummyRequest(
+            method='PUT', json_body=vacuous_input, matchdict={'old_id': old_id})
+        vacuous_response = v.old(request)
+        self.assertEqual(3, len(self.session.query(m.OLD).all())) # no db changes
+        self.assertEqual(response, vacuous_response)
+
+        # Silent update fails accompanied by successful ones do mutate db
+        valid_input = {'slug': 'okana',
+                       'state': m.old_state.failed_to_sync,
+                       'name': 'Nsyilxcen'}
+        request = testing.DummyRequest(
+            method='PUT', json_body=valid_input, matchdict={'old_id': old_id})
+        response = v.old(request)
+        self.assertEqual(4, len(self.session.query(m.OLD).all())) # db changes
+        self.assertEqual('Nsyilxcen', response['name'])
+
+        # Transition the OLD state
+        request = testing.DummyRequest(
+            method='PUT', json_body={'state': 'syncing'},
+            matchdict={'old_id': old_id})
+        response = v.old_state(request)
+        self.assertEqual(5, len(self.session.query(m.OLD).all())) # db changes
+        self.assertEqual('syncing', response['state'])
+
+        # Vacuous transition has no effect
+        request = testing.DummyRequest(
+            method='PUT', json_body={'state': 'syncing'},
+            matchdict={'old_id': old_id})
+        response = v.old_state(request)
+        self.assertEqual(5, len(self.session.query(m.OLD).all())) # db changes
+        self.assertEqual('syncing', response['state'])
+
+        # Transition with a numeric state fails
+        request = testing.DummyRequest(
+            method='PUT', json_body={'state': 0},
+            matchdict={'old_id': old_id})
+        response = v.old_state(request)
+        self.assertIn('state must be one of', response['error'])
+
+        # An illegal transition (syncing => not_synced) fails
+        request = testing.DummyRequest(
+            method='PUT', json_body={'state': 'not_synced'},
+            matchdict={'old_id': old_id})
+        response = v.old_state(request)
+        self.assertEqual(5, len(self.session.query(m.OLD).all())) # no db changes
+        self.assertEqual('illegal state transition', response['error'])
+
+        # A legal transition (syncing => synced) succeeds
+        request = testing.DummyRequest(
+            method='PUT', json_body={'state': 'synced'},
+            matchdict={'old_id': old_id})
+        response = v.old_state(request)
+        self.assertEqual(6, len(self.session.query(m.OLD).all())) # db changes
+        self.assertEqual('synced', response['state'])
+
+        # Delete the OLD
+        request = testing.DummyRequest(
+            method='DELETE', matchdict={'old_id': old_id})
+        response = v.old(request)
+        self.assertEqual(6, len(self.session.query(m.OLD).all())) # end updated
+        self.assertGreater(m.get_now(),
+                           self.session.query(m.OLD).filter(
+                               m.OLD.history_id == old_id).order_by(
+                                   desc(m.OLD.start)).first().end)


### PR DESCRIPTION
## Rationale

We need to be able to perform CRUD actions on the OLD resource. This change exposes an HTTP JSON API to do that.

## Changes

- Add endpoints for OLD resource:
  - Create OLD: `POST /olds`
  - Read OLDs: `GET /olds`
  - Read OLD: `GET /olds/{old_id}`
  - Update OLD: `PUT /olds/{old_id}`
  - Transition OLD state: `PUT /olds/{old_id}/state`
  - Delete OLD: `DELETE /olds/{old_id}`
- The authentication credentials of the OLD's leader are the username and password attributes of each OLD
- Validation on attribute mutation, in particular only allow valid OLD state transitions
- Tests
- Add `/dative_app` endpoint to router (previous omission)