### PR TITLE
Add SyncOLDCommands API endpoints

### DIFF
--- a/src/dativetop/server/dativetopserver/models.py
+++ b/src/dativetop/server/dativetopserver/models.py
@@ -294,6 +294,12 @@ def get_olds():
 # acked:    c.acked = True  (active)
 # complete: c.end   < now
 
+def serialize_sync_old_command(sync_old_command):
+    return {'id': sync_old_command.history_id,
+            'old_id': sync_old_command.old_id,
+            'acked': sync_old_command.acked}
+
+
 def enqueue_sync_old_command(old_id):
     """Enqueue a sync-OLD! command."""
     now = get_now()

--- a/src/dativetop/server/dativetopserver/views.py
+++ b/src/dativetop/server/dativetopserver/views.py
@@ -412,10 +412,10 @@ def old_state(request):
 
 
 # OLDSyncCommand API:
-# Enqueue:  POST /sync_old_commands
-# Pop:      PUT  /sync_old_commands
-# Read:     GET  /sync_old_commands/{id}
-# Complete: PUT  /sync_old_commands/{id}
+# Enqueue:  POST   /sync_old_commands
+# Pop:      PUT    /sync_old_commands
+# Read:     GET    /sync_old_commands/{id}
+# Complete: DELETE /sync_old_commands/{id}
 
 def enqueue_command(request):
     payload, error = get_json_payload(request)


### PR DESCRIPTION
## Rationale

Fixes https://github.com/dativebase/dativetop/issues/14

## Changes

- GET /sync_old_commands/{command_id} => read cmd
- DELETE /sync_old_commands/{command_id} => complete cmd
- POST /sync_old_commands => enqueue new cmd
- PUT /sync_old_commands => pop/ack next cmd