### PR TITLE
Add OLD server view to DTGUI

### DIFF
--- a/src/dativetop/gui/README.rst
+++ b/src/dativetop/gui/README.rst
@@ -57,3 +57,19 @@ Notes
 
 - click "Fetch Server State"
   - dispatch :poll-server-state
+
+
+Documentation notes
+=============================================================================
+
+DativeTop is an application for linguistic data management.
+
+It lets you manage Online Linguistic Database (OLD) instances on your local
+machine and configure them to sync with leader OLDs on the web.
+
+DativeTop lets you use the Dative graphical user interface to work with your
+OLD instances.
+
+To view Dative, click the "View" menu item and then "Dative". Click the
+"Help" menu item and then "Visit Dative in Browser" to open Dative in
+your web browser.

--- a/src/dativetop/server/README.rst
+++ b/src/dativetop/server/README.rst
@@ -25,3 +25,46 @@ Open a shell::
 
     $ pshell config.ini
 
+
+API
+================================================================================
+
+All database changes in this API are non-lossy, meaning that SQL ``update`` is
+only used to deactivate a row, i.e., to set its ``end`` value to the current
+date-time. All other updates are actually row deactivations followed by the
+creation of a new row with the updated data.
+
+- /old_service
+
+  - GET: fetch the OLD service
+  - PUT: update the URL of the OLD service
+
+- /dative_app
+
+  - GET: fetch the Dative app
+  - PUT: update the URL of the Dative app
+
+- /olds
+
+  - GET: fetch all of the OLDs
+  - POST: create a new OLD
+
+- /olds/{old_id}
+
+  - GET: fetch a specific OLD
+  - PUT: update an OLD
+  - DELETE: delete an OLD
+
+- /olds/{old_id}/state
+
+  - PUT: transition an OLD's state
+
+- /sync_old_commands
+
+  - POST: enqueue a new command
+  - PUT: pop the next command off of the queue
+
+- /sync_old_commands/{command_id}
+
+  - GET: fetch a specific command
+  - DELETE: complete a command

--- a/src/dativetop/server/dativetopserver/__init__.py
+++ b/src/dativetop/server/dativetopserver/__init__.py
@@ -2,7 +2,7 @@ from pyramid.config import Configurator
 from sqlalchemy import engine_from_config
 
 from .models import DBSession, Base
-import dativetopserver.views as views
+import dativetopserver.views as v
 
 
 def main(global_config, **settings):
@@ -13,11 +13,44 @@ def main(global_config, **settings):
     Base.metadata.bind = engine
     config = Configurator(settings=settings)
     config.include('pyramid_chameleon')
+    config.include('pyramid_tm')
     config.include('dativetopserver.cors')
     config.add_cors_preflight_handler()
-    config.add_route('append-only-log', '/')
-    config.add_view(views.append_only_log,
-                    route_name='append-only-log',
+
+    config.add_route('old-service', '/old_service')
+    config.add_view(v.old_service,
+                    route_name='old-service',
                     renderer='json')
+
+    config.add_route('dative-app', '/dative_app')
+    config.add_view(v.dative_app,
+                    route_name='dative-app',
+                    renderer='json')
+
+    config.add_route('old_state', '/olds/{old_id}/state')
+    config.add_view(v.old_state,
+                    route_name='old_state',
+                    renderer='json')
+
+    config.add_route('old', '/olds/{old_id}')
+    config.add_view(v.old,
+                    route_name='old',
+                    renderer='json')
+
+    config.add_route('olds', '/olds')
+    config.add_view(v.olds,
+                    route_name='olds',
+                    renderer='json')
+
+    config.add_route('sync_old_command', '/sync_old_commands/{command_id}')
+    config.add_view(v.sync_old_command,
+                    route_name='sync_old_command',
+                    renderer='json')
+
+    config.add_route('sync_old_commands', '/sync_old_commands')
+    config.add_view(v.sync_old_commands,
+                    route_name='sync_old_commands',
+                    renderer='json')
+
     config.scan()
     return config.make_wsgi_app()

--- a/src/dativetop/server/dativetopserver/views.py
+++ b/src/dativetop/server/dativetopserver/views.py
@@ -73,29 +73,6 @@ def append_to_log(request):
     return []
 
 
-def get_append_only_log(request):
-    logger.info('MONKEYS!')
-    tip_hash = request.GET.get('head')
-    logger.info('Returning the AOL after hash %s', tip_hash)
-    aol = aol_mod.get_aol(AOL_PATH)
-    ret = aol_mod.get_new_appendables(aol, tip_hash)
-    logger.info('Returning AOL suffix of %s elements', len(ret))
-    return ret
-
-
-def append_only_log(request):
-    """Handle all requests. There is only one endpoint, the AOL root endoint at
-    /. Only 2 HTTP methods are accepted: PUT and GET. PUT is for appending, GET
-    is for reading.
-    """
-    if request.method == 'PUT':
-        return append_to_log(request)
-    if request.method == 'GET':
-        return get_append_only_log(request)
-    request.response.status = 405
-    return {'error': 'Only GET and PUT requests are permitted.'}
-
-
 def validate_local_url(url):
     parsed = urlparse(url.rstrip('/'))
     if not parsed.port:
@@ -530,11 +507,6 @@ def main(ip, port):
     config.add_route('sync_old_commands', '/sync_old_commands')
     config.add_view(sync_old_commands,
                     route_name='sync_old_commands',
-                    renderer='json')
-
-    config.add_route('append-only-log', '/')
-    config.add_view(append_only_log,
-                    route_name='append-only-log',
                     renderer='json')
 
     app = config.make_wsgi_app()


### PR DESCRIPTION
## Rationale

Addresses https://github.com/dativebase/dativetop/issues/19.

## Changes

- Add view for OLD server
  - DTGUI page now simply shows the URL of the OLD server
  - Remove now unused code
  - Move some copy/notes to the README
- Fix DTServer routes and transaction machinery
  - Copy routes to ``dativetopserver/__init__.py::main``, making them effective.
  - Include `pyramid_tm` so that requests run within a db transaction
  - Add DTServer API summary to README
  - Remove unused AOL handlers