### PR TITLE
Use DTServer as source of truth

### DIFF
--- a/src/dativetop/constants.py
+++ b/src/dativetop/constants.py
@@ -13,22 +13,17 @@ ICONS_FILE_NAME = 'dativetop.icns'
 ICONS_FILE_PATH = os.path.join('resources', ICONS_FILE_NAME)
 IP = '127.0.0.1'
 
-DATIVE_PORT = 5678
 DATIVE_ROOT = os.path.join(HERE, 'dative', 'dist')
-DATIVE_URL = 'http://{}:{}/'.format(IP, DATIVE_PORT)
 DATIVE_WEB_SITE_URL = 'http://www.dative.ca/'
-DATIVE_WEBSITE_URL = 'http://www.dative.ca/'
 
 DATIVETOP_GUI_PORT = 5677
 DATIVETOP_GUI_ROOT = os.path.join(HERE, 'dativetop', 'gui', 'target')
-DATIVETOP_GUI_URL = 'http://{}:{}/'.format(IP, DATIVETOP_GUI_PORT)
+DATIVETOP_GUI_URL = f'http://{IP}:{DATIVETOP_GUI_PORT}/'
 
 DATIVETOP_SERVER_PORT = 5676
 DATIVETOP_SERVER_DIR = os.path.join(HERE, 'dativetop', 'server')
-DATIVETOP_SERVER_URL = 'http://{}:{}/'.format(IP, DATIVETOP_SERVER_PORT)
+DATIVETOP_SERVER_URL = f'http://{IP}:{DATIVETOP_SERVER_PORT}/'
 
 OLD_DIR = os.path.join(HERE, 'old')
 OLD_LOGO_PNG_PATH = 'private_resources/icons-originals/OLD-logo.png'
-OLD_PORT = 5679
-OLD_URL = 'http://{}:{}/'.format(IP, OLD_PORT)
 OLD_WEB_SITE_URL = 'http://www.onlinelinguisticdatabase.org/'

--- a/src/dativetop/gui/Makefile
+++ b/src/dativetop/gui/Makefile
@@ -6,6 +6,11 @@ run-repl:  ## Run DativeTop GUI in development and start a REPL connected to the
 		split-window -h \; \
 		send-keys 'yarn shadow-cljs cljs-repl dativetop-gui' \;
 
+build:  ## Build under target/
+	@mkdir -p target; \
+		cp -r assets/* target/; \
+		npx shadow-cljs release dativetop-gui
+
 help:  ## Print this help message.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 

--- a/src/dativetop/gui/assets/index.html
+++ b/src/dativetop/gui/assets/index.html
@@ -1,15 +1,20 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset='utf-8'>
-    <link rel="stylesheet" href="css/bootstrap.css">
-    <link rel="stylesheet" href="css/material-design-iconic-font.min.css">
-    <link rel="stylesheet" href="css/re-com.css">
-    <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700,400italic" type="text/css">
-    <link rel="stylesheet" href='http://fonts.googleapis.com/css?family=Roboto+Condensed:400,300' type='text/css'>
-  </head>
-  <body>
-    <div id="app"></div>
-    <script src="main.js"></script>
-  </body>
+    <head>
+        <meta charset='utf-8'>
+        <link rel="stylesheet" href="css/bootstrap.css">
+        <link rel="stylesheet" href="css/material-design-iconic-font.min.css">
+        <link rel="stylesheet" href="css/re-com.css">
+        <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700,400italic" type="text/css">
+        <link rel="stylesheet" href='http://fonts.googleapis.com/css?family=Roboto+Condensed:400,300' type='text/css'>
+    </head>
+    <body>
+        <div id="app"></div>
+        <script>
+         window.DativeAppURL = "http://127.0.0.1:77777"
+         window.OLDServiceURL = "http://127.0.0.1:8888"
+         window.DativeTopServerURL = "http://127.0.0.1:4676"
+        </script>
+        <script src="main.js"></script>
+    </body>
 </html>

--- a/src/dativetop/gui/shadow-cljs.edn
+++ b/src/dativetop/gui/shadow-cljs.edn
@@ -18,11 +18,12 @@
                 ]
  :nrepl {:port 8092}
  :dev-http {8090 "target/"}
- :builds {:dativetop-gui {:output-dir "target/"
-                          :asset-path "."
-                          :target :browser
-                          :modules {:main {:init-fn dativetop-gui.core/run}}
-                          :devtools {:after-load dativetop-gui.core/run
-                                     :http-root "target"
-                                     :http-port 8090}}}}
+ :builds {:dativetop-gui
+          {:output-dir "target/"
+           :asset-path "."
+           :target :browser
+           :modules {:main {:init-fn dativetop-gui.core/run}}
+           :devtools {:after-load dativetop-gui.core/run
+                      :http-root "target"
+                      :http-port 8090}}}}
 

--- a/src/dativetop/introspect.py
+++ b/src/dativetop/introspect.py
@@ -1,8 +1,6 @@
-"""Code for introspecting the running services:
-
-    - Check that Dative GUI, DativeTop GUI, DativeTop Server and OLD Service
-      are all running.
-    - Return a list of OLD Instances that we can log in to.
+"""Code for introspecting the running services. The ``confirm_services_up``
+function confirms that all supplied ``utils.Service`` instances supplied are
+running and accessible at their URLs.
 """
 
 import logging
@@ -18,109 +16,37 @@ import dativetop.constants as c
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_URLS = (('Dative', c.DATIVE_URL),
-                ('DativeTop GUI', c.DATIVETOP_GUI_URL),
-                ('DativeTop Server', c.DATIVETOP_SERVER_URL),
-                # OLD needs a subpath under /
-                ('OLD Service', f'{c.OLD_URL}root/'),)
-
 MAX_ATTEMPTS = 3
 
 
-def _find_possible_old_instance_names(dativetop_settings):
-    """Return a list of OLD instance dicts, deduced by inspecting the
-    .sqlite files listed under ``config['old_db_dirpath']``. Aside from the
-    defaults, the file system data gives us the name and local URL of each
-    instance.
-    """
-    old_instances = []
-    old_db_dirpath = dativetop_settings.get('old_db_dirpath')
-    if old_db_dirpath and os.path.isdir(old_db_dirpath):
-        for e_name in os.listdir(old_db_dirpath):
-            e_path = os.path.join(old_db_dirpath, e_name)
-            if os.path.isfile(e_path):
-                old_name, ext = os.path.splitext(e_name)
-                if ext == '.sqlite':
-                    old_instances.append(
-                        {'local_path': e_path,
-                         'db_file_name': old_name,
-                         'url': f'{c.OLD_URL}{old_name}',})
-    return old_instances
+def normalize_url(service):
+    if 'DTServer' == service.name:
+        return f'{service.url}/olds'
+    if 'OLDService' == service.name:
+        return f'{service.url}/root/'
+    return service.url
 
 
-def _determine_running_old_instances(dativetop_settings):
-    """Return a list of dicts representing the OLD instances that are actually
-    running locally.
-
-    .. warning:: We accomplish this verification by logging into each OLD
-                 serially. Aside from the possible performance issue of serial
-                 HTTP requests, this skirts the issue that some OLD instances
-                 might have modified credentials. Credential management must be
-                 dealt with.
-    """
-    ret = []
-    username = dativetop_settings['dflt_old_username']
-    password = dativetop_settings['dflt_old_password']
-    hidden_password = '*' * len(password)
-    for oi_dict in _find_possible_old_instance_names(
-            dativetop_settings):
-        url = oi_dict['url']
-        old_client = oc.OLDClient(url)
-        can_login = old_client.login(username, password)
-        if not can_login:
-            logger.warning(
-                'Cannot login to local OLD at %s using username %s and password'
-                ' %s.', url, username, hidden_password)
-            continue
-        ret.append({'url': oi_dict['url'],
-                    'slug': oi_dict['db_file_name'],})
-    return ret
-
-
-def _get_domain_entities(dativetop_settings):
-    """Return a dict describing the DativeTop domain entities. This is
-    information that will need to be communicated to the DativeTop Server.
-    """
-    return {
-        'dative_app': {'url': c.DATIVE_URL},
-        'old_service': {'url': c.OLD_URL},
-        'old_instances': _determine_running_old_instances(dativetop_settings)}
-
-
-def _confirm_all_services_up(attempt_count=1, wait=1, urls=None):
-    urls = urls or DEFAULT_URLS
+def confirm_services_up(services, attempt_count=1, wait=1):
     failed = []
-    for name, url in urls:
+    for service in services:
         try:
+            url = normalize_url(service)
             resp = requests.get(url)
             resp.raise_for_status()
-        except:
-            failed.append((name, url))
+        except Exception as e:
+            failed.append(service)
         else:
-            logger.info('%s is running at %s', name, url)
+            logger.info('%s is running at %s', service.name, service.url)
     if failed and attempt_count < MAX_ATTEMPTS:
         time.sleep(wait)
-        return _confirm_all_services_up(
+        return confirm_services_up(
+            failed,
             attempt_count=attempt_count + 1,
-            wait=wait * 2,
-            urls=failed)
+            wait=wait * 2)
     if failed:
-        failed_str = ', '.join('{0} at {1}'.format(*s) for s in failed)
+        failed_str = ', '.join(f'{s.name} at {s.url}' for s in failed)
         msg = f'Failed to detect the following service(s): {failed_str}.'
         logger.error(msg)
         return None, msg
     return True, None
-
-
-def introspect(dativetop_settings):
-    """Confirm that we can reach each of the local services. Return a dict of
-    domain entities; this should be information about the local DativeApp,
-    OLDService and OLDInstances that can be communicated to the DativeTop
-    Server service.
-    """
-    _, err = _confirm_all_services_up()
-    if err:
-        logger.error(err)
-        return None, err
-    logger.info('All DativeTop services are running locally!')
-    return _get_domain_entities(dativetop_settings), None

--- a/src/dativetop/serve/dative.py
+++ b/src/dativetop/serve/dative.py
@@ -5,14 +5,12 @@ thread, using a Python server.
 """
 
 from dativetop.serve.servejsapp import serve_local_js_app
-from dativetop.constants import (
-    IP,
-    DATIVE_PORT,
-    DATIVE_URL,
-    DATIVE_ROOT,
-)
+from dativetop.constants import DATIVE_ROOT
+import dativetop.utils as dtutils
 
 
-def serve_dative():
-    return serve_local_js_app(
-        'Dative', IP, DATIVE_PORT, DATIVE_URL, DATIVE_ROOT)
+def serve_dative(dative):
+    return dtutils.Service(
+        name=dative.name,
+        url=dative.url,
+        stopper=serve_local_js_app(dative.name, dative.url, DATIVE_ROOT))

--- a/src/dativetop/serve/dativetopgui.py
+++ b/src/dativetop/serve/dativetopgui.py
@@ -4,16 +4,34 @@ Functionality for serving the Dative ClojureScript SPA locally, in a separate
 thread, using a Python server.
 """
 
+import os
+
+from dativetop.constants import DATIVETOP_GUI_URL, DATIVETOP_GUI_ROOT
 from dativetop.serve.servejsapp import serve_local_js_app
-from dativetop.constants import (
-    IP,
-    DATIVETOP_GUI_PORT,
-    DATIVETOP_GUI_URL,
-    DATIVETOP_GUI_ROOT,
-)
+import dativetop.utils as dtutils
 
 
-def serve_dativetop_gui():
-    return serve_local_js_app(
-        'DativeTop', IP, DATIVETOP_GUI_PORT, DATIVETOP_GUI_URL,
-        DATIVETOP_GUI_ROOT)
+def _repair_dativetop_gui_index_html(old_service, dative_app, dtserver):
+    index_path = os.path.join(DATIVETOP_GUI_ROOT, 'index.html')
+    new_path = []
+    with open(index_path) as f:
+        for l in f:
+            if 'window.DativeAppURL' in l:
+                new_path.append('        window.DativeAppURL = "{}";\n'.format(dative_app.url))
+            elif 'window.OLDServiceURL' in l:
+                new_path.append('        window.OLDServiceURL = "{}";\n'.format(old_service.url))
+            elif 'window.DativeTopServerURL' in l:
+                new_path.append('        window.DativeTopServerURL = "{}";\n'.format(dtserver.url))
+            else:
+                new_path.append(l)
+    with open(index_path, 'w') as f:
+        f.write(''.join(new_path))
+
+
+def serve_dativetop_gui(old_service, dative_app, dtserver):
+    _repair_dativetop_gui_index_html(old_service, dative_app, dtserver)
+    return dtutils.Service(
+        name='DTGUI',
+        url=DATIVETOP_GUI_URL,
+        stopper=serve_local_js_app('DTGUI', DATIVETOP_GUI_URL, DATIVETOP_GUI_ROOT))
+

--- a/src/dativetop/serve/dativetopserver.py
+++ b/src/dativetop/serve/dativetopserver.py
@@ -4,12 +4,8 @@ Functionality for serving the DativeTop Server Pyramid web service locally, in
 a new process.
 """
 
-from dativetop.constants import (
-    IP,
-    DATIVETOP_SERVER_DIR,
-    DATIVETOP_SERVER_PORT,
-    DATIVETOP_SERVER_URL,
-)
+import dativetop.utils as dtutils
+from dativetop.constants import DATIVETOP_SERVER_DIR, DATIVETOP_SERVER_URL
 from dativetop.serve.pyramidapp import serve_pyr
 
 
@@ -19,6 +15,9 @@ def serve_dativetop_server():
     subprocess that invokes the pserve executable. Return a function that stops
     serving the OLD.
     """
-    return serve_pyr(
-        'DativeTop Server', IP, DATIVETOP_SERVER_PORT, DATIVETOP_SERVER_URL,
-        DATIVETOP_SERVER_DIR)
+    # TODO: dynamically generate available DTServer URL ...
+    return dtutils.Service(
+        name='DTServer',
+        url=DATIVETOP_SERVER_URL,
+        stopper=serve_pyr(
+            'DativeTop Server', DATIVETOP_SERVER_URL, DATIVETOP_SERVER_DIR))

--- a/src/dativetop/serve/old.py
+++ b/src/dativetop/serve/old.py
@@ -4,12 +4,16 @@ Functionality for serving the OLD Pyramid web service locally, in a new
 process, using the pserve Python server.
 """
 
-from dativetop.constants import IP, OLD_PORT, OLD_URL, OLD_DIR
+from dativetop.constants import OLD_DIR
 from dativetop.serve.pyramidapp import serve_pyr
+import dativetop.utils as dtutils
 
 
-def serve_old():
+def serve_old(old):
     """Serve the OLD locally in a separate thread that forks a subprocess that
     invokes the pserve executable. Return a function that stops serving the OLD.
     """
-    return serve_pyr('The OLD', IP, OLD_PORT, OLD_URL, OLD_DIR)
+    return dtutils.Service(
+        name=old.name,
+        url=old.url,
+        stopper=serve_pyr(old.name, old.url, OLD_DIR))

--- a/src/dativetop/serve/pyramidapp.py
+++ b/src/dativetop/serve/pyramidapp.py
@@ -9,21 +9,23 @@ import os
 import shlex
 import subprocess
 import threading
+import urllib.parse
 
 
 logger = logging.getLogger(__name__)
 
-def _fork_server_process(ip, port, root_path, config='config.ini'):
+
+def _fork_server_process(url, root_path, config='config.ini'):
     """Use Pyramid's pserve executable to serve the Pyramid app in a new
     process.
     """
+    parse = urllib.parse.urlparse(url)
     os.chdir(root_path)
     cmd = (
         f'pserve'
-        f' --reload'
         f' {config}'
-        f' http_port={port}'
-        f' http_host={ip}')
+        f' http_port={parse.port}'
+        f' http_host={parse.hostname}')
     cmd = shlex.split(cmd)
     # FIXME: this is still needed in a built (e.g., DativeTop.app) app...
     # './../../../python/bin/pserve'
@@ -46,12 +48,12 @@ def _monitor_server_process(process=None, name=None):
     return rc
 
 
-def serve_pyr(name, ip, port, url, root_path, config='config.ini'):
+def serve_pyr(name, url, root_path, config='config.ini'):
     """Serve the Pyramid app locally in a separate thread that forks a
     subprocess that invokes the pserve executable. Return a function that stops
     serving the Pyramid app.
     """
-    process = _fork_server_process(ip, port, root_path, config=config)
+    process = _fork_server_process(url, root_path, config=config)
     thread = threading.Thread(
         target=_monitor_server_process,
         kwargs={'process': process, 'name': name,},

--- a/src/dativetop/serve/servejsapp.py
+++ b/src/dativetop/serve/servejsapp.py
@@ -79,13 +79,16 @@ class CustomTCPServer(socketserver.TCPServer):
         self.socket.bind(self.server_address)
 
 
-def serve_local_js_app(name, ip, port, url, root_path):
+def serve_local_js_app(name, url, root_path):
     """Serve the local JS app at ip:port in a separate thread.
 
     Return an argument-less func that, when called, will stop the local server
     and close the thread.
     """
-    OurCustomHTTPHandler =  get_custom_http_handler(name, root_path)
+    parse = urllib.parse.urlparse(url)
+    ip = parse.hostname
+    port = parse.port
+    OurCustomHTTPHandler = get_custom_http_handler(name, root_path)
     our_server = CustomTCPServer((ip, port), OurCustomHTTPHandler)
     thread = threading.Thread(
         target=_serve_local_js_app,

--- a/src/dativetop/utils.py
+++ b/src/dativetop/utils.py
@@ -1,8 +1,13 @@
+from collections import namedtuple
 import io
 import json
 import logging
 import os
 import re
+
+
+Service = namedtuple('Service', 'name, url, stopper')
+
 
 from dativetop.constants import (
     DATIVE_ROOT,


### PR DESCRIPTION
## Rationale

Resolves https://github.com/dativebase/dativetop/issues/25

## Changes

- Update DativeTop to use DTServer as source of truth
  - The app module now starts up DTServer first, then fetches the OLDService and DativeApp state from DTServer. It then uses that state to start up the OLDService and DativeApp services.
- Update DTGUI for DTServer as source of truth
    - Modify DTGUI poll DTServer for updates every 2s   
- Bump OLD to 8ad936f Read-only Mode
