### PR TITLE
Create sync-OLD! commands

### DIFF
--- a/src/dativetop/app.py
+++ b/src/dativetop/app.py
@@ -36,6 +36,7 @@ import dativetop.constants as c
 import dativetop.introspect as dti
 import dativetop.javascripts as dtjs
 import dativetop.serve as dtserve
+import dativetop.syncmanager as syncmanager
 import dativetop.utils as dtutils
 
 
@@ -120,6 +121,7 @@ class DativeTop(toga.App):
         self.main_window.content = self.dativetop_gui
         self.main_window.show()
         self.verify_services()
+        syncmanager.start_sync_manager(self.services.dtserver)
 
     def verify_services(self):
         thread = threading.Thread(
@@ -440,7 +442,6 @@ class DativeTop(toga.App):
             visit_dative_web_site_cmd,
         )
         #self.main_window.toolbar.add(about_cmd, quit_cmd)
-
 
 
 def fetch_old_service():

--- a/src/dativetop/server/dativetopserver/models.py
+++ b/src/dativetop/server/dativetopserver/models.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 import datetime
 import json
+import logging
 import transaction
 from uuid import uuid4
 
@@ -30,6 +31,9 @@ from sqlalchemy.orm import (
 )
 
 from zope.sqlalchemy import register
+
+
+logger = logging.getLogger(__name__)
 
 
 DBSession = scoped_session(sessionmaker())

--- a/src/dativetop/server/dativetopserver/models.py
+++ b/src/dativetop/server/dativetopserver/models.py
@@ -300,6 +300,14 @@ def serialize_sync_old_command(sync_old_command):
             'acked': sync_old_command.acked}
 
 
+def get_open_sync_old_commands():
+    """Get all currently open (not acked) sync-OLD! commands."""
+    return DBSession.query(SyncOLDCommand).filter(
+        SyncOLDCommand.end > get_now(),
+        SyncOLDCommand.acked.is_(False)
+    ).order_by(asc(SyncOLDCommand.start)).all()
+
+
 def enqueue_sync_old_command(old_id):
     """Enqueue a sync-OLD! command."""
     now = get_now()

--- a/src/dativetop/server/dativetopserver/views.py
+++ b/src/dativetop/server/dativetopserver/views.py
@@ -389,10 +389,17 @@ def old_state(request):
 
 
 # OLDSyncCommand API:
+# Index:    GET    /sync_old_commands
 # Enqueue:  POST   /sync_old_commands
 # Pop:      PUT    /sync_old_commands
-# Read:     GET    /sync_old_commands/{id}
+# Show:     GET    /sync_old_commands/{id}
 # Complete: DELETE /sync_old_commands/{id}
+
+
+def index_commands(request):
+    return [m.serialize_sync_old_command(c) for c in
+            m.get_open_sync_old_commands()]
+
 
 def enqueue_command(request):
     payload, error = get_json_payload(request)
@@ -418,7 +425,7 @@ def pop_command(request):
     return m.serialize_sync_old_command(command)
 
 
-def read_command(request):
+def show_command(request):
     command_id = request.matchdict['command_id']
     try:
         command = m.get_sync_old_command(command_id)
@@ -439,6 +446,8 @@ def complete_command(request):
 
 
 def sync_old_commands(request):
+    if request.method == 'GET':
+        return index_commands(request)
     if request.method == 'POST':
         return enqueue_command(request)
     if request.method == 'PUT':
@@ -450,7 +459,7 @@ def sync_old_commands(request):
 
 def sync_old_command(request):
     if request.method == 'GET':
-        return read_command(request)
+        return show_command(request)
     if request.method == 'DELETE':
         return complete_command(request)
     request.response.status = 405

--- a/src/dativetop/server/dativetopserver/views.py
+++ b/src/dativetop/server/dativetopserver/views.py
@@ -19,11 +19,11 @@ logging_config = dict(
     handlers={
         'h': {'class': 'logging.StreamHandler',
               'formatter': 'f',
-              'level': logging.DEBUG}
+              'level': logging.INFO}
     },
     root={
         'handlers': ['h'],
-        'level': logging.DEBUG,
+        'level': logging.INFO,
     },
 )
 
@@ -397,9 +397,14 @@ def old_state(request):
 
 
 def index_commands(request):
-    return [m.serialize_sync_old_command(c) for c in
-            m.get_open_sync_old_commands()]
-
+    try:
+        return [m.serialize_sync_old_command(c) for c in
+                m.get_open_sync_old_commands()]
+    except Exception as e:
+        msg = 'Failed to fetch all sync-OLD! commands'
+        logger.exception(msg)
+        request.response.status = 500
+        return {'error': msg}
 
 def enqueue_command(request):
     payload, error = get_json_payload(request)

--- a/src/dativetop/syncmanager.py
+++ b/src/dativetop/syncmanager.py
@@ -1,0 +1,79 @@
+"""The SyncManager is a single thread of execution that is responsible for
+creating sync-OLD! commands.
+
+The SyncManager performs these steps in a loop:
+
+1. Ask DTServer for all open (un-acknowledged) sync-OLD! Commands.
+2. Ask DTServer for all OLDs.
+3. Identify all auto-syncing OLDs lacking open commands.
+4. Create a sync-OLD! command for each OLD identified in (3).
+5. Sleep for a time, then return to (1).
+"""
+
+import logging
+import pprint
+import requests
+import threading
+import time
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_open_sync_old_commands(dtserver):
+    try:
+        return requests.get(f'{dtserver.url}sync_old_commands').json()
+    except Exception as e:
+        logger.exception('Failed to fetch sync-OLD! commands')
+        return []
+
+
+def enqueue_sync_old_command(dtserver, old_id):
+    try:
+        return requests.post(
+            f'{dtserver.url}sync_old_commands',
+            json={'old_id': old_id}).json()
+    except Exception as e:
+        msg = f'Failed to enqueue a sync-OLD! command for OLD {old_id}'
+        logger.exception(msg)
+        return {'error': msg}
+
+
+def get_olds(dtserver):
+    try:
+        return requests.get(f'{dtserver.url}olds').json()
+    except Exception as e:
+        logger.exception('Failed to fetch OLDs')
+        return []
+
+
+def sync_manager(dtserver):
+    while True:
+        try:
+            commands = get_open_sync_old_commands(dtserver)
+            olds = get_olds(dtserver)
+            command_old_ids = [soc['old_id'] for soc in commands]
+            olds_needing_commands = [
+                old['id'] for old in olds
+                if old['is_auto_syncing'] and old['id'] not in command_old_ids]
+            for old_id in olds_needing_commands:
+                enqueue_resp = enqueue_sync_old_command(dtserver, old_id)
+                error = enqueue_resp.get('error')
+                if error:
+                    logger.error(error)
+                else:
+                    logger.info(f'Enqueued sync-OLD! command for OLD'
+                                f'{enqueue_resp["old_id"]}')
+        except Exception as e:
+            logger.exception('SyncManager failed when attempting to create new'
+                             ' sync-OLD! commands')
+        finally:
+            time.sleep(2)
+
+
+def start_sync_manager(dtserver):
+    thread = threading.Thread(
+        target=sync_manager,
+        kwargs={'dtserver': dtserver},
+        daemon=True)
+    thread.start()


### PR DESCRIPTION
## Rationale

We need a system that ensures that new sync-OLD! commands are created when needed. This PR resolves https://github.com/dativebase/dativetop/issues/26.

## Changes

- Add syncmanager thread. It is responsible for enqueuing sync-OLD! commands.
- Add GET /sync_old_commands endpoint. It returns an array of all non-acked sync-OLD! commands.
- Improve logging and error handling in DTServer (silence library DEBUG logs.)