### PR TITLE
Sync readonly olds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,16 @@ serve-dt-server:  ## Serve the DativeTop Server Pyramid process independently
 	cd ${HERE}/src/dativetop/server; \
     ${HERE}/../venv3.6.5/bin/pserve --reload config.ini http_port=4676 http_host=127.0.0.1
 
+destroy-olds:  ## Destroy all OLD instances. !!!DANGER!!!
+	@rm -f src/old/*.sqlite; \
+		rm -rf src/old/store/*
+
+refresh-dtserver:  ## Destroy and recreate the DTServer database
+	@rm -f src/dativetop/server/dativetop.sqlite; \
+		${HERE}/../venv3.6.5/bin/initialize_dtserver_db src/dativetop/server/config.ini
+
+refresh-dativetop: destroy-olds refresh-dtserver  ## Clear the DTServer db and remove all OLDs !!!DANGER!!!
+
 help:  ## Print this help message.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 

--- a/src/dativetop/app.py
+++ b/src/dativetop/app.py
@@ -37,6 +37,7 @@ import dativetop.introspect as dti
 import dativetop.javascripts as dtjs
 import dativetop.serve as dtserve
 import dativetop.syncmanager as syncmanager
+import dativetop.syncworker as syncworker
 import dativetop.utils as dtutils
 
 
@@ -122,6 +123,8 @@ class DativeTop(toga.App):
         self.main_window.show()
         self.verify_services()
         syncmanager.start_sync_manager(self.services.dtserver)
+        syncworker.start_sync_worker(
+            self.services.dtserver, self.services.old_service)
 
     def verify_services(self):
         thread = threading.Thread(

--- a/src/dativetop/app.py
+++ b/src/dativetop/app.py
@@ -200,15 +200,15 @@ class DativeTop(toga.App):
         about_window.show()
 
     async def copy_cmd(self, _):
-        clip = await self.dative_gui.evaluate_javascript(dtjs.COPY_SELECTION_JS)
+        clip = await self.main_window.content.evaluate_javascript(dtjs.COPY_SELECTION_JS)
         return pyperclip.copy(str(clip))
 
     async def cut_cmd(self, _):
-        clip = await self.dative_gui.evaluate_javascript(dtjs.CUT_SELECTION_JS)
+        clip = await self.main_window.content.evaluate_javascript(dtjs.CUT_SELECTION_JS)
         return pyperclip.copy(str(clip))
 
     async def select_all_cmd(self, _):
-        await self.dative_gui.evaluate_javascript(dtjs.SELECT_ALL_JS)
+        await self.main_window.content.evaluate_javascript(dtjs.SELECT_ALL_JS)
 
     async def reset_dative_app_settings_cmd(self, sender):
         """TODO: this does not seem to work ..."""
@@ -247,7 +247,7 @@ class DativeTop(toga.App):
         logger.debug(pprint.pformat(len(app_settings)))
 
     async def paste_cmd(self, _):
-        await self.dative_gui.evaluate_javascript(
+        await self.main_window.content.evaluate_javascript(
             dtjs.paste_js(pyperclip.paste().replace('`', r'\`')))
 
     def reload_cmd(self, _):
@@ -423,10 +423,10 @@ class DativeTop(toga.App):
             about_cmd,
             quit_cmd,
             # Edit
-            # cut_cmd,
-            # copy_cmd,
-            # paste_cmd,
-            # select_all_cmd,
+            cut_cmd,
+            copy_cmd,
+            paste_cmd,
+            select_all_cmd,
             # View
             reload_cmd,
             reset_cmd,

--- a/src/dativetop/javascripts.py
+++ b/src/dativetop/javascripts.py
@@ -17,22 +17,22 @@ COPY_SELECTION_JS = (
 
 # JavaScript/jQuery to cut (copy and remove) any selected text
 CUT_SELECTION_JS = (
-    "var focused = $(':focus');\n"
-    "var focused_ntv = focused[0];\n"
-    "var start = focused_ntv.selectionStart;\n"
-    "var end = focused_ntv.selectionEnd;\n"
-    "var focused_val = focused.val();\n"
-    "var new_focused_val = focused_val.slice(0, start) + "
-    "focused_val.slice(end, focused_val.length);\n"
-    "focused.val(new_focused_val);\n"
-    "focused_ntv.setSelectionRange(start, start);\n"
-    "focused_val.slice(start, end);"
+    "var focused = document.activeElement;\n"
+    "var start = focused.selectionStart;\n"
+    "var end = focused.selectionEnd;\n"
+    "var val = focused.value;\n"
+    "var new_val = val.slice(0, start) + val.slice(end, val.length);\n"
+    "focused.value = new_val;\n"
+    "focused.setSelectionRange(start, start);\n"
+    "val.slice(start, end);"
 )
 
 
 # JavaScript/jQuery to select all text
 SELECT_ALL_JS = (
-    "$(':focus').select();"
+    "var focused = document.activeElement;\n"
+    "var val = focused.value;\n"
+    "focused.setSelectionRange(0, val.length);"
 )
 
 
@@ -41,17 +41,15 @@ def paste_js(clipboard):
     element in the DOM using JavaScript/jQuery.
     """
     return (
-        f"var focused = $(':focus');\n"
-        f"var focused_ntv = focused[0];\n"
-        f"var start = focused_ntv.selectionStart;\n"
-        f"var end = focused_ntv.selectionEnd;\n"
-        f"var focused_val = focused.val();\n"
-        f"focused.val(focused_val.slice(0, start) + "
-        f"`{clipboard}` + focused_val.slice(end, focused_val.length));\n"
+        f"var focused = document.activeElement;\n"
+        f"var start = focused.selectionStart;\n"
+        f"var end = focused.selectionEnd;\n"
+        f"var val = focused.value;\n"
+        f"var new_val = val.slice(0, start) + `{clipboard}` + val.slice(end, val.length);\n"
+        f"focused.value = new_val;\n"
         f"var cursorPos = start + `{clipboard}`.length;\n"
-        f"focused_ntv.setSelectionRange(cursorPos, cursorPos);"
+        f"focused.setSelectionRange(cursorPos, cursorPos);"
     )
-
 
 DESTROY_DATIVE_APP_SETTINGS = (
     "localStorage.removeItem('dativeApplicationSettings');"

--- a/src/dativetop/serve/old.py
+++ b/src/dativetop/serve/old.py
@@ -16,4 +16,5 @@ def serve_old(old):
     return dtutils.Service(
         name=old.name,
         url=old.url,
-        stopper=serve_pyr(old.name, old.url, OLD_DIR))
+        stopper=serve_pyr(old.name, old.url, OLD_DIR,
+                          config='configlocal.ini'))

--- a/src/dativetop/server/dativetopserver/models.py
+++ b/src/dativetop/server/dativetopserver/models.py
@@ -320,11 +320,11 @@ def enqueue_sync_old_command(old_id):
         SyncOLDCommand.old_id == old_id,
     ).first()
     if existing_command:
-        return existing_command
+        return existing_command, 'found'
     command = SyncOLDCommand(old_id=old_id) # enqueued
     DBSession.add(command)
     DBSession.flush()
-    return command
+    return command, 'created'
 
 
 def get_sync_old_command(sync_old_command_id):

--- a/src/dativetop/server/dativetopserver/views.py
+++ b/src/dativetop/server/dativetopserver/views.py
@@ -419,7 +419,11 @@ def enqueue_command(request):
     except NoResultFound:
         request.response.status = 404
         return {'error': 'No OLD with supplied ID'}
-    return m.serialize_sync_old_command(m.enqueue_sync_old_command(old_id))
+    cmd, status = m.enqueue_sync_old_command(old_id)
+    request.response.status = 201
+    if status == 'found':
+        request.response.status = 200
+    return m.serialize_sync_old_command(cmd)
 
 
 def pop_command(request):

--- a/src/dativetop/syncworker.py
+++ b/src/dativetop/syncworker.py
@@ -1,0 +1,383 @@
+"""The SyncWorker is a single thread of execution that is responsible for
+executing sync-OLD! commands.
+
+The SyncWorker performs these steps in a loop:
+
+1. Using DTServer, pop the next sync-OLD! command off of the queue.
+2. Determine whether the OLD already exists and create it if it does not.
+3. Fetch the last modified values for each resource in the local OLD.
+4. Fetch the last modified values for each resource in the remote OLD.
+5. Compute a diff in order to determine required updates, deletes and adds.
+6. Fetch the remote resources that have been updated or added.
+7. Mutate the local OLD's SQLite db so that it matchees the remote leader.
+8. Sleep and then return to (1).
+"""
+
+import datetime
+import json
+import logging
+import os
+import shlex
+import subprocess
+import threading
+import time
+
+from oldclient import OLDClient
+import requests
+import sqlalchemy as sqla
+
+import dativetop.constants as c
+
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_LOCAL_OLD_USERNAME = 'admin'
+DEFAULT_LOCAL_OLD_PASSWORD = 'adminA_1'
+
+
+def parse_datetime_string(datetime_string):
+    return datetime.datetime.strptime(datetime_string, '%Y-%m-%dT%H:%M:%S.%f')
+
+
+def parse_date_string(date_string):
+    return datetime.datetime.strptime(date_string, '%Y-%m-%d').date()
+
+
+def prepare_value_for_upsert(table_name, k, v):
+    if 'datetime_' in k and v:
+        try:
+            return parse_datetime_string(v)
+        except Exception as e:
+            logger.warning(
+                'Failed to parse value "%s" as datetime in table %s, column %s.',
+                v, table_name, k)
+            raise e
+    if 'date_' in k and v:
+        try:
+            return parse_date_string(v)
+        except Exception as e:
+            logger.warning(
+                'Failed to parse value "%s" as date in table %s, column %s.',
+                v, table_name, k)
+            raise e
+    return v
+
+
+def prepare_row_for_upsert(table_name, row):
+    row = {k: prepare_value_for_upsert(table_name, k, v)
+           for k, v in row.items()}
+    if table_name == 'user':
+        del row['password']
+        del row['salt']
+    return row
+
+
+def pop_sync_old_command(dtserver):
+    try:
+        response = requests.put(f'{dtserver.url}sync_old_commands')
+        if response.status_code == 404:
+            logger.debug('No sync-OLD! messages currently on the queue')
+            return None
+        if response.status_code == 200:
+            return response.json()
+        logger.error(
+            'Received an unexpected response code %s when attempting to pop'
+            ' the next sync-OLD! command.', response.status_code)
+        return None
+    except Exception:
+        msg = 'Failed to pop the next sync-OLD! command from DTServer'
+        logger.exception(msg)
+        return None
+
+
+def complete_sync_old_command(dtserver, command):
+    try:
+        response = requests.delete(
+            f'{dtserver.url}sync_old_commands/{command["id"]}')
+        if response.status_code == 404:
+            logger.warning(
+                f'Failed to complete command {command["id"]}: it does not'
+                f' exist.')
+            return None
+        if response.status_code == 200:
+            return response.json()
+        logger.error(
+            'Received an unexpected response code %s when attempting to'
+            ' complete sync-OLD! command %s.',
+            response.status_code,
+            command['id'])
+        return None
+    except Exception:
+        msg = f'Failed to complete sync-OLD! command {command["id"]}.'
+        logger.exception(msg)
+        return None
+
+
+def handle_command(command, old_service):
+    """
+    1. identify the OLD from the command
+    {'acked': True,
+     'id': 'cbcfb97d-6f72-4851-997d-173560c6173d',
+     'old_id': 'd9d5563d-a29a-46b3-85f2-6a3a1104f7fa'}
+    """
+    return None
+
+
+def fetch_old(dtserver, old_id):
+    try:
+        return requests.get(f'{dtserver.url}olds/{old_id}').json()
+    except Exception:
+        logger.exception('Failed to fetch OLD %s', old_id)
+        return None
+
+
+def old_store_dir_exists(old):
+    old_store_dir = os.path.join(c.OLD_DIR, 'store', old['slug'])
+    return os.path.isdir(old_store_dir)
+
+
+def can_authenticate_to_old(old):
+    old_client = OLDClient(old['url'])
+    try:
+        return old_client.login(
+            DEFAULT_LOCAL_OLD_USERNAME,
+            DEFAULT_LOCAL_OLD_PASSWORD)
+    except Exception as e:
+        logger.warning(
+            f'Exception of type {type(e)} when attempting to'
+            f' authenticate to the OLD')
+        return False
+
+
+def authenticate_to_leader(old):
+    logger.debug(
+        f'checking if we can login to the leader OLD at {old["leader"]}'
+        f' using username {old["username"]} and password'
+        f' {old["password"]}')
+    old_client = OLDClient(old['leader'])
+    try:
+        logged_in = old_client.login(old['username'], old['password'])
+        if logged_in:
+            return old_client
+        return False
+    except Exception:
+        logger.exception(f'Failed to login to the leader OLD {old["leader"]}')
+        return False
+
+
+def does_old_exist(old):
+    dir_exists = old_store_dir_exists(old)
+    if dir_exists:
+        can_auth = can_authenticate_to_old(old)
+        if can_auth:
+            return True
+    return False
+
+
+def get_dative_servers(path):
+    with open(path) as filei:
+        return json.load(filei)
+
+
+def write_dative_servers(servers, path):
+    with open(path, 'w') as fileo:
+        json.dump(servers, fileo)
+
+
+def generate_old_dict(old):
+    return {'name': old['name'],
+            'type': 'OLD',
+            'url': old['url'],
+            'serverCode': None,
+            'corpusServerURL': None,
+            'website': 'http://www.onlinelinguisticdatabase.org'}
+
+
+def register_old_with_dative(old):
+    try:
+        servers_path = os.path.join(c.DATIVE_ROOT, 'servers.json')
+        servers = get_dative_servers(servers_path)
+        old_dict = generate_old_dict(old)
+        if old_dict in servers:
+            return True
+        servers.append(old_dict)
+        write_dative_servers(servers, servers_path)
+        return True
+    except Exception:
+        logger.warning(f'Failed to register OLD {old["slug"]} with Dative')
+        return False
+
+
+def unregister_old_with_dative(old):
+    servers_path = os.path.join(c.DATIVE_ROOT, 'servers.json')
+    servers = get_dative_servers(servers_path)
+    old_dict = generate_old_dict(old)
+    if old_dict in servers:
+        servers = [s for s in servers if s != old_dict]
+        write_dative_servers(servers, servers_path)
+
+
+def create_local_old(old):
+    os.chdir(c.OLD_DIR)
+    cmd = f'initialize_old configlocal.ini {old["slug"]}'
+    logger.debug(f'Running command {cmd} to create the {old["slug"]} OLD')
+    cmd = shlex.split(cmd)
+    child = subprocess.Popen(cmd,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT)
+    child.communicate()
+    if child.returncode != 0:
+        logger.warning(f'Failed to create new local OLD {old["slug"]}')
+        return False
+    logger.info(f'Successfully issued the command to create the new local OLD'
+                f' {old["slug"]}')
+    old_exists = does_old_exist(old)
+    if not old_exists:
+        logger.warning(f'Failed to create new local OLD {old["slug"]}')
+        return False
+    logger.info(f'Confirmed that the new local OLD {old["slug"]} exists')
+    is_registered = register_old_with_dative(old)
+    if not is_registered:
+        logger.warning(f'Failed to register local OLD {old["slug"]} with Dative')
+        return False
+    logger.info(f'Registered local OLD {old["slug"]} with Dative')
+    logger.info(f'Created new local OLD {old["slug"]}')
+    return True
+
+
+class SyncOLDError(Exception):
+    pass
+
+
+def get_diff(prev, curr):
+    diff = {'delete': {}, 'add': {}, 'update': {}}
+    for table, ids in prev.items():
+        for id_, modified in ids.items():
+            if id_ not in curr[table]:
+                diff['delete'].setdefault(table, []).append(int(id_))
+            elif modified != curr[table][id_]:
+                diff['update'].setdefault(table, []).append(int(id_))
+    for table, ids in curr.items():
+        for id_, modified in ids.items():
+            if id_ not in prev[table]:
+                diff['add'].setdefault(table, []).append(int(id_))
+    return diff
+
+
+def process_command(dtserver, old_service, command):
+    """Process a sync-OLD! command."""
+
+    # Get the OLD metadata from DTServer
+    old = fetch_old(dtserver, command['old_id'])
+    old['url'] = f'{old_service.url}/{old["slug"]}'
+
+    # Determine whether the OLD already exists and create it if necessary
+    old_exists = does_old_exist(old)
+    if not old_exists:
+        old_exists = create_local_old(old)
+        if not old_exists:
+            msg = f'Attempting to create the OLD {old["slug"]} locally'
+            logger.warning(msg)
+            raise SyncOLDError(msg)
+
+    # Abort if we are not set to sync or if there is nothing to sync with
+    if not old['is_auto_syncing']:
+        logger.debug(f'OLD {old["slug"]} is not set to auto-sync')
+        return
+    if not old['leader']:
+        logger.debug(f'OLD {old["slug"]} has no remote leader OLD')
+        return
+    leader_client = authenticate_to_leader(old)
+    if not leader_client:
+        logger.warning(f'Unable to login to leader OLD {old["leader"]}')
+        return
+
+    # Fetch the last modified values for each resource in the local OLD and in
+    # the leader OLD and construct a diff.
+    local_client = OLDClient(old['url'])
+    local_client.login(
+        DEFAULT_LOCAL_OLD_USERNAME,
+        DEFAULT_LOCAL_OLD_PASSWORD)
+    local_last_mod = local_client.get('sync/last_modified')
+    leader_last_mod = leader_client.get('sync/last_modified')
+    diff = get_diff(local_last_mod, leader_last_mod)
+
+    # Perform the local updates by modifying the SQLite db of the OLD directly.
+    db_path = os.path.join(c.OLD_DIR, f"{old['slug']}.sqlite")
+    engine = sqla.create_engine(f'sqlite:///{db_path}')
+    meta = sqla.MetaData()
+
+    # TODO: consider performing all of the following in a transaction.
+
+    # Perform any deletions
+    delete_state = diff['delete']
+    if delete_state:
+        with engine.connect() as conn:
+            for table_name, rows in delete_state.items():
+                if not rows:
+                    continue
+                table = sqla.Table(table_name, meta, autoload_with=engine)
+                conn.execute(
+                    table.delete().where(
+                        table.c.id.in_(rows)))
+
+    # Perform any additions
+    add_params = diff['add']
+    if add_params:
+        add_state = leader_client.post('sync/tables', {'tables': add_params})
+        with engine.connect() as conn:
+            for table_name, rows in add_state.items():
+                if not rows:
+                    continue
+                table = sqla.Table(table_name, meta, autoload_with=engine)
+                conn.execute(
+                    table.insert(),
+                    [prepare_row_for_upsert(table_name, row)
+                     for row in rows.values()])
+
+    # Perform any updates
+    update_params = diff['update']
+    if update_params:
+        update_state = leader_client.post('sync/tables', {'tables': update_params})
+        with engine.connect() as conn:
+            for table_name, rows in update_state.items():
+                if not rows:
+                    continue
+                table = sqla.Table(table_name, meta, autoload_with=engine)
+                for row in rows.values():
+                    row_id = row['id']
+                    updated_row = prepare_row_for_upsert(table_name, row)
+                    conn.execute(
+                        table.update().where(
+                            table.c.id == row_id).values(**updated_row))
+
+
+def sync_worker(dtserver, old_service):
+    while True:
+        try:
+            # Pop and then process the next sync-OLD! command
+            command = pop_sync_old_command(dtserver)
+            if not command:
+                continue
+            process_command(dtserver, old_service, command)
+        except SyncOLDError as e:
+            logger.exception(str(e))
+        except Exception as e:
+            logger.exception(
+                'Unexpected exception during SyncWorker\'s attempt to process'
+                ' the next sync-OLD! command')
+        finally:
+            # Tell DTServer that we have finished processing the command.
+            if command:
+                complete_sync_old_command(dtserver, command)
+            time.sleep(2)
+
+
+def start_sync_worker(dtserver, old_service):
+    thread = threading.Thread(
+        target=sync_worker,
+        kwargs={'dtserver': dtserver,
+                'old_service': old_service},
+        daemon=True)
+    thread.start()


### PR DESCRIPTION
Addresses https://github.com/dativebase/dativetop/issues/27

Sync read-only OLDs by adding SyncWorker which executes sync-OLD! commands

- The SyncWorker is a single thread of execution that is responsible for executing sync-OLD! commands.
- The SyncWorker performs these steps in a loop:
  1. Using DTServer, pop the next sync-OLD! command off of the queue.
  2. Determine whether the OLD already exists and create it if it does not.
  3. Fetch the last modified values for each resource in the local OLD.
  4. Fetch the last modified values for each resource in the remote OLD.
  5. Compute a diff in order to determine required updates, deletes and adds.
  6. Fetch the remote resources that have been updated or added.
  7. Mutate the local OLD's SQLite db so that it matches the remote leader.
  8. Sleep and then return to (i).